### PR TITLE
feat(dashboard): add static dashboard and example submissions

### DIFF
--- a/dashboard/data/submissions.json
+++ b/dashboard/data/submissions.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": 1,
+    "title": "AI-Powered Inventory Alert System",
+    "submitter": "Alex Chen",
+    "status": "invested",
+    "category": "ai-ml",
+    "score": 21,
+    "cycle": "Q1-2026",
+    "summary": "Predicts stock shortages using historical data and sends Slack alerts before stockouts occur.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/1"
+  },
+  {
+    "id": 2,
+    "title": "Meeting Decision Recorder",
+    "submitter": "Priya Sharma",
+    "status": "selected",
+    "category": "ai-ml",
+    "score": 19,
+    "cycle": "Q1-2026",
+    "summary": "Extracts action items and decisions from meeting transcripts using LLM summarization.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/2"
+  },
+  {
+    "id": 3,
+    "title": "Customer Feedback Classifier",
+    "submitter": "Jordan Lee",
+    "status": "graduated",
+    "category": "ai-ml",
+    "score": 23,
+    "cycle": "Q4-2025",
+    "summary": "Categorizes support tickets by intent and urgency, routing critical issues to senior agents.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/3"
+  },
+  {
+    "id": 4,
+    "title": "Automated Expense Report Processor",
+    "submitter": "Maria Garcia",
+    "status": "submitted",
+    "category": "automation",
+    "score": 0,
+    "cycle": "Q1-2026",
+    "summary": "Scans receipt images, extracts amounts and categories, and auto-fills expense report forms.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/4"
+  },
+  {
+    "id": 5,
+    "title": "Internal Knowledge Graph Search",
+    "submitter": "David Kim",
+    "status": "under-review",
+    "category": "data",
+    "score": 0,
+    "cycle": "Q1-2026",
+    "summary": "Connects Confluence, SharePoint, and Slack data into a unified semantic search interface.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/5"
+  },
+  {
+    "id": 6,
+    "title": "CI/CD Pipeline Health Monitor",
+    "submitter": "Sam Okafor",
+    "status": "shelved",
+    "category": "infrastructure",
+    "score": 14,
+    "cycle": "Q4-2025",
+    "summary": "Aggregates build metrics across repos and flags degrading pipelines before they break.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/6"
+  },
+  {
+    "id": 7,
+    "title": "Onboarding Checklist Generator",
+    "submitter": "Lisa Nguyen",
+    "status": "under-review",
+    "category": "process",
+    "score": 0,
+    "cycle": "Q1-2026",
+    "summary": "Generates role-specific onboarding checklists from team docs and past onboarding feedback.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/7"
+  },
+  {
+    "id": 8,
+    "title": "Accessibility Audit Scanner",
+    "submitter": "Tom Eriksson",
+    "status": "invested",
+    "category": "ux",
+    "score": 18,
+    "cycle": "Q1-2026",
+    "summary": "Crawls internal web apps and generates WCAG compliance reports with fix suggestions.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/8"
+  },
+  {
+    "id": 9,
+    "title": "Sales Data Anomaly Detector",
+    "submitter": "Fatima Al-Rashid",
+    "status": "submitted",
+    "category": "data",
+    "score": 0,
+    "cycle": "Q1-2026",
+    "summary": "Monitors daily sales figures and flags statistically significant deviations in real time.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/9"
+  },
+  {
+    "id": 10,
+    "title": "Vendor Contract Renewal Tracker",
+    "submitter": "Raj Patel",
+    "status": "selected",
+    "category": "automation",
+    "score": 17,
+    "cycle": "Q1-2026",
+    "summary": "Parses vendor contracts for renewal dates and sends escalating reminders to procurement.",
+    "url": "https://github.com/rajnavakoti/prototype-ops/issues/10"
+  }
+]

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prototype-Ops Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+  <!-- Header -->
+  <header class="site-header" role="banner">
+    <h1>Prototype-Ops Dashboard</h1>
+    <div class="header-meta">
+      <span class="cycle-badge" id="cycle-indicator" aria-label="Current evaluation cycle">Q1-2026</span>
+      <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark and light mode" type="button">DARK</button>
+    </div>
+  </header>
+
+  <!-- Main Content -->
+  <main class="main-container" role="main">
+
+    <!-- Stats Bar -->
+    <section class="stats-bar" aria-label="Submission statistics">
+      <div class="stat-card">
+        <span class="stat-value mono" id="stat-total">--</span>
+        <span class="stat-label">Total Submissions</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-value mono" id="stat-review">--</span>
+        <span class="stat-label">Under Review</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-value mono" id="stat-invested">--</span>
+        <span class="stat-label">Invested</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-value mono" id="stat-graduated">--</span>
+        <span class="stat-label">Graduated</span>
+      </div>
+    </section>
+
+    <!-- Pipeline Visualization -->
+    <section class="section" aria-label="Submission pipeline">
+      <h2 class="section-title">Pipeline</h2>
+      <div class="pipeline" id="pipeline" role="list" aria-label="Pipeline stages"></div>
+    </section>
+
+    <!-- Category Breakdown -->
+    <section class="section" aria-label="Category breakdown">
+      <h2 class="section-title">Categories</h2>
+      <table class="category-table" id="category-table" aria-label="Submissions by category">
+        <thead>
+          <tr>
+            <th scope="col">Category</th>
+            <th scope="col">Count</th>
+            <th scope="col">Distribution</th>
+          </tr>
+        </thead>
+        <tbody id="category-body"></tbody>
+      </table>
+    </section>
+
+    <!-- Filters -->
+    <section class="section" aria-label="Submission filters">
+      <h2 class="section-title">Submissions</h2>
+      <div class="filters">
+        <div class="filter-group">
+          <label for="filter-status">Status</label>
+          <select id="filter-status" aria-label="Filter by status">
+            <option value="all">All Statuses</option>
+          </select>
+        </div>
+        <div class="filter-group">
+          <label for="filter-category">Category</label>
+          <select id="filter-category" aria-label="Filter by category">
+            <option value="all">All Categories</option>
+          </select>
+        </div>
+        <div class="filter-group">
+          <label for="filter-cycle">Cycle</label>
+          <select id="filter-cycle" aria-label="Filter by cycle">
+            <option value="all">All Cycles</option>
+          </select>
+        </div>
+      </div>
+    </section>
+
+    <!-- Submission Cards -->
+    <section class="section" aria-label="Submission cards">
+      <div class="cards-grid" id="cards-grid"></div>
+      <div class="empty-state" id="empty-state" hidden>No submissions match the selected filters.</div>
+    </section>
+
+  </main>
+
+  <!-- Footer -->
+  <footer class="site-footer" role="contentinfo">
+    Prototype-Ops &mdash; Channel the energy, don't fight it
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      /* ---- State ---- */
+      var submissions = [];
+      var filters = { status: 'all', category: 'all', cycle: 'all' };
+
+      var PIPELINE_ORDER = [
+        'submitted',
+        'under-review',
+        'selected',
+        'invested',
+        'graduated',
+        'shelved',
+        'killed'
+      ];
+
+      /* ---- Theme Toggle ---- */
+      var themeToggle = document.getElementById('theme-toggle');
+      var root = document.documentElement;
+
+      function applyTheme(theme) {
+        root.setAttribute('data-theme', theme);
+        themeToggle.textContent = theme === 'dark' ? 'LIGHT' : 'DARK';
+        themeToggle.setAttribute('aria-label', 'Switch to ' + (theme === 'dark' ? 'light' : 'dark') + ' mode');
+        try { localStorage.setItem('proto-ops-theme', theme); } catch (e) { /* no-op */ }
+      }
+
+      themeToggle.addEventListener('click', function () {
+        var current = root.getAttribute('data-theme');
+        applyTheme(current === 'dark' ? 'light' : 'dark');
+      });
+
+      /* Restore saved theme */
+      try {
+        var saved = localStorage.getItem('proto-ops-theme');
+        if (saved) { applyTheme(saved); }
+      } catch (e) { /* no-op */ }
+
+      /* ---- Data Fetch ---- */
+      fetch('data/submissions.json')
+        .then(function (res) {
+          if (!res.ok) throw new Error('Failed to load submissions data');
+          return res.json();
+        })
+        .then(function (data) {
+          submissions = data;
+          populateFilters();
+          renderAll();
+        })
+        .catch(function (err) {
+          document.getElementById('empty-state').hidden = false;
+          document.getElementById('empty-state').textContent = 'Error loading data: ' + err.message;
+        });
+
+      /* ---- Filter Logic ---- */
+      function populateFilters() {
+        var statuses = unique(submissions.map(function (s) { return s.status; }));
+        var categories = unique(submissions.map(function (s) { return s.category; }));
+        var cycles = unique(submissions.map(function (s) { return s.cycle; }));
+
+        fillSelect('filter-status', statuses);
+        fillSelect('filter-category', categories);
+        fillSelect('filter-cycle', cycles);
+
+        document.getElementById('filter-status').addEventListener('change', onFilterChange);
+        document.getElementById('filter-category').addEventListener('change', onFilterChange);
+        document.getElementById('filter-cycle').addEventListener('change', onFilterChange);
+      }
+
+      function fillSelect(id, values) {
+        var select = document.getElementById(id);
+        values.forEach(function (v) {
+          var opt = document.createElement('option');
+          opt.value = v;
+          opt.textContent = formatLabel(v);
+          select.appendChild(opt);
+        });
+      }
+
+      function onFilterChange() {
+        filters.status = document.getElementById('filter-status').value;
+        filters.category = document.getElementById('filter-category').value;
+        filters.cycle = document.getElementById('filter-cycle').value;
+        renderCards();
+      }
+
+      function getFiltered() {
+        return submissions.filter(function (s) {
+          if (filters.status !== 'all' && s.status !== filters.status) return false;
+          if (filters.category !== 'all' && s.category !== filters.category) return false;
+          if (filters.cycle !== 'all' && s.cycle !== filters.cycle) return false;
+          return true;
+        });
+      }
+
+      /* ---- Render Functions ---- */
+      function renderAll() {
+        renderStats();
+        renderPipeline();
+        renderCategoryTable();
+        renderCards();
+      }
+
+      function renderStats() {
+        document.getElementById('stat-total').textContent = submissions.length;
+        document.getElementById('stat-review').textContent = countByStatus('under-review');
+        document.getElementById('stat-invested').textContent = countByStatus('invested');
+        document.getElementById('stat-graduated').textContent = countByStatus('graduated');
+      }
+
+      function renderPipeline() {
+        var container = document.getElementById('pipeline');
+        container.innerHTML = '';
+
+        PIPELINE_ORDER.forEach(function (stage, i) {
+          var count = countByStatus(stage);
+          var div = document.createElement('div');
+          div.className = 'pipeline-stage' + (count > 0 ? ' active' : '');
+          div.setAttribute('role', 'listitem');
+          div.innerHTML =
+            '<span class="stage-count">' + count + '</span>' +
+            '<span class="stage-label">' + formatLabel(stage) + '</span>';
+          container.appendChild(div);
+        });
+      }
+
+      function renderCategoryTable() {
+        var body = document.getElementById('category-body');
+        body.innerHTML = '';
+        var cats = countByField('category');
+        var max = Math.max.apply(null, Object.values(cats));
+
+        Object.keys(cats).sort().forEach(function (cat) {
+          var count = cats[cat];
+          var pct = max > 0 ? Math.round((count / max) * 100) : 0;
+          var tr = document.createElement('tr');
+          tr.innerHTML =
+            '<td>' + formatLabel(cat) + '</td>' +
+            '<td>' + count + '</td>' +
+            '<td class="bar-cell"><div class="bar-track"><div class="bar-fill" style="width:' + pct + '%"></div></div></td>';
+          body.appendChild(tr);
+        });
+      }
+
+      function renderCards() {
+        var grid = document.getElementById('cards-grid');
+        var empty = document.getElementById('empty-state');
+        var filtered = getFiltered();
+        grid.innerHTML = '';
+
+        if (filtered.length === 0) {
+          empty.hidden = false;
+          return;
+        }
+        empty.hidden = true;
+
+        filtered.forEach(function (s) {
+          var card = document.createElement('article');
+          card.className = 'submission-card';
+          card.innerHTML =
+            '<div class="card-header">' +
+              '<h3 class="card-title"><a href="' + escapeHtml(s.url) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(s.title) + '</a></h3>' +
+              '<span class="status-badge" data-status="' + escapeHtml(s.status) + '">' + formatLabel(s.status) + '</span>' +
+            '</div>' +
+            '<div class="card-meta">' +
+              '<span>' + escapeHtml(s.submitter) + '</span>' +
+              '<span class="category-tag">' + formatLabel(s.category) + '</span>' +
+              '<span>' + escapeHtml(s.cycle) + '</span>' +
+            '</div>' +
+            '<p class="card-summary">' + escapeHtml(s.summary) + '</p>' +
+            '<div class="card-footer">' +
+              '<span class="card-score" aria-label="Score: ' + s.score + ' out of 25">' + (s.score > 0 ? s.score + '/25' : '--') + '</span>' +
+              '<span class="category-tag">#' + escapeHtml(s.id.toString()) + '</span>' +
+            '</div>';
+          grid.appendChild(card);
+        });
+      }
+
+      /* ---- Utilities ---- */
+      function countByStatus(status) {
+        return submissions.filter(function (s) { return s.status === status; }).length;
+      }
+
+      function countByField(field) {
+        var counts = {};
+        submissions.forEach(function (s) {
+          var key = s[field];
+          counts[key] = (counts[key] || 0) + 1;
+        });
+        return counts;
+      }
+
+      function unique(arr) {
+        var seen = {};
+        return arr.filter(function (v) {
+          if (seen[v]) return false;
+          seen[v] = true;
+          return true;
+        });
+      }
+
+      function formatLabel(str) {
+        return str.replace(/-/g, ' ').replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+      }
+
+      function escapeHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+      }
+    })();
+  </script>
+
+</body>
+</html>

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1,0 +1,671 @@
+/* ============================================================
+   Prototype-Ops Dashboard — Neo-Brutalist Monochrome Stylesheet
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* --- Custom Properties (Light Mode Default) --- */
+:root {
+  /* Colors */
+  --color-bg: #FFF;
+  --color-text: #000;
+  --color-text-secondary: #333;
+  --color-text-muted: #666;
+  --color-border: #000;
+  --color-surface: #F5F5F5;
+  --color-surface-alt: #EEE;
+  --color-header-bg: #000;
+  --color-header-text: #FFF;
+  --color-table-header-bg: #000;
+  --color-table-header-text: #FFF;
+  --color-table-row-alt: #F5F5F5;
+  --color-input-bg: #FFF;
+  --color-badge-bg: #EEE;
+  --color-badge-text: #000;
+  --color-pipeline-fill: #000;
+  --color-pipeline-track: #EEE;
+  --color-bar-bg: #000;
+
+  /* Borders */
+  --border-thin: 1px solid var(--color-border);
+  --border-medium: 2px solid var(--color-border);
+  --border-heavy: 3px solid var(--color-border);
+
+  /* Typography */
+  --font-mono: 'JetBrains Mono', monospace;
+  --font-body: system-ui, -apple-system, sans-serif;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.25rem;
+  --font-size-xl: 1.5rem;
+  --font-size-2xl: 2rem;
+  --font-size-3xl: 3rem;
+
+  /* Spacing */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-2xl: 48px;
+}
+
+/* --- Dark Mode --- */
+[data-theme="dark"] {
+  --color-bg: #111;
+  --color-text: #EEE;
+  --color-text-secondary: #CCC;
+  --color-text-muted: #999;
+  --color-border: #EEE;
+  --color-surface: #222;
+  --color-surface-alt: #333;
+  --color-header-bg: #EEE;
+  --color-header-text: #000;
+  --color-table-header-bg: #EEE;
+  --color-table-header-text: #000;
+  --color-table-row-alt: #222;
+  --color-input-bg: #222;
+  --color-badge-bg: #333;
+  --color-badge-text: #EEE;
+  --color-pipeline-fill: #EEE;
+  --color-pipeline-track: #333;
+  --color-bar-bg: #EEE;
+}
+
+/* --- Reset & Base --- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  line-height: 1.5;
+}
+
+/* --- Typography --- */
+h1, h2, h3, h4 {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+h1 { font-size: var(--font-size-2xl); }
+h2 { font-size: var(--font-size-xl); }
+h3 { font-size: var(--font-size-lg); }
+h4 { font-size: var(--font-size-base); }
+
+code, .mono {
+  font-family: var(--font-mono);
+}
+
+/* --- Links --- */
+a {
+  color: var(--color-text);
+  text-decoration: underline;
+}
+
+a:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+a:focus-visible {
+  outline: 3px solid var(--color-text);
+  outline-offset: 2px;
+}
+
+/* --- Header --- */
+.site-header {
+  background-color: var(--color-header-bg);
+  color: var(--color-header-text);
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: var(--border-heavy);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+}
+
+.site-header h1 {
+  font-size: var(--font-size-xl);
+  letter-spacing: -0.02em;
+}
+
+.header-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.cycle-badge {
+  border: 2px solid var(--color-header-text);
+  padding: var(--space-xs) var(--space-sm);
+  font-weight: 700;
+}
+
+/* --- Theme Toggle --- */
+.theme-toggle {
+  background-color: var(--color-header-text);
+  color: var(--color-header-bg);
+  border: 2px solid var(--color-header-text);
+  padding: var(--space-xs) var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+  border-radius: 0;
+}
+
+.theme-toggle:hover {
+  background-color: var(--color-header-bg);
+  color: var(--color-header-text);
+}
+
+.theme-toggle:focus-visible {
+  outline: 3px solid var(--color-header-text);
+  outline-offset: 2px;
+}
+
+/* --- Main Container --- */
+.main-container {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: var(--space-lg);
+}
+
+/* --- Stats Bar --- */
+.stats-bar {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+}
+
+.stat-card {
+  border: var(--border-heavy);
+  padding: var(--space-md);
+  background-color: var(--color-surface);
+}
+
+.stat-card .stat-value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-3xl);
+  font-weight: 700;
+  line-height: 1;
+  display: block;
+}
+
+.stat-card .stat-label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  margin-top: var(--space-xs);
+  display: block;
+}
+
+/* --- Section --- */
+.section {
+  margin-bottom: var(--space-2xl);
+}
+
+.section-title {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-lg);
+  border-bottom: var(--border-heavy);
+  padding-bottom: var(--space-sm);
+  margin-bottom: var(--space-md);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* --- Pipeline Visualization --- */
+.pipeline {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  border: var(--border-heavy);
+  overflow-x: auto;
+}
+
+.pipeline-stage {
+  flex: 1;
+  min-width: 120px;
+  padding: var(--space-md);
+  text-align: center;
+  border-right: var(--border-medium);
+  background-color: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-xs);
+}
+
+.pipeline-stage:last-child {
+  border-right: none;
+}
+
+.pipeline-stage .stage-count {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.pipeline-stage .stage-label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.pipeline-stage .stage-arrow {
+  font-size: var(--font-size-lg);
+  color: var(--color-text-muted);
+}
+
+.pipeline-stage.active {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.pipeline-stage.active .stage-label {
+  color: var(--color-bg);
+  opacity: 0.7;
+}
+
+/* --- Category Breakdown --- */
+.category-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: var(--border-heavy);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.category-table thead th {
+  background-color: var(--color-table-header-bg);
+  color: var(--color-table-header-text);
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: var(--font-size-xs);
+  border-bottom: var(--border-heavy);
+}
+
+.category-table tbody td {
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: var(--border-thin);
+}
+
+.category-table tbody tr:nth-child(even) {
+  background-color: var(--color-table-row-alt);
+}
+
+.category-table tbody tr:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.bar-cell {
+  width: 50%;
+}
+
+.bar-track {
+  width: 100%;
+  height: 16px;
+  background-color: var(--color-pipeline-track);
+  border: var(--border-thin);
+  position: relative;
+}
+
+.bar-fill {
+  height: 100%;
+  background-color: var(--color-bar-bg);
+}
+
+/* --- Filter Controls --- */
+.filters {
+  display: flex;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.filter-group label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+}
+
+.filter-group select {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-medium);
+  border-radius: 0;
+  background-color: var(--color-input-bg);
+  color: var(--color-text);
+  cursor: pointer;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  min-width: 160px;
+}
+
+.filter-group select:focus-visible {
+  outline: 3px solid var(--color-text);
+  outline-offset: 2px;
+}
+
+/* --- Submission Cards Grid --- */
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: var(--space-md);
+}
+
+.submission-card {
+  border: var(--border-heavy);
+  padding: var(--space-md);
+  background-color: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.submission-card:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.submission-card:hover .card-meta,
+.submission-card:hover .card-summary,
+.submission-card:hover .stat-label {
+  color: var(--color-bg);
+  opacity: 0.8;
+}
+
+.submission-card:hover .status-badge {
+  border-color: var(--color-bg);
+  color: var(--color-bg);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-sm);
+}
+
+.card-title {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.card-title a {
+  text-decoration: none;
+}
+
+.card-title a:hover {
+  text-decoration: underline;
+  background: none;
+  color: inherit;
+}
+
+.card-meta {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  display: flex;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.card-summary {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+  padding-top: var(--space-sm);
+  border-top: var(--border-thin);
+}
+
+.card-score {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: var(--font-size-lg);
+}
+
+/* --- Status Badges --- */
+.status-badge {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px var(--space-sm);
+  border: var(--border-medium);
+  display: inline-block;
+  white-space: nowrap;
+}
+
+.status-badge[data-status="submitted"] {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  border-style: dashed;
+}
+
+.status-badge[data-status="under-review"] {
+  background-color: var(--color-surface-alt);
+  color: var(--color-text);
+}
+
+.status-badge[data-status="selected"] {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.status-badge[data-status="invested"] {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+  border-width: 3px;
+}
+
+.status-badge[data-status="graduated"] {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+  border-style: double;
+  border-width: 4px;
+}
+
+.status-badge[data-status="shelved"] {
+  background-color: var(--color-surface-alt);
+  color: var(--color-text-muted);
+  border-style: dotted;
+}
+
+.status-badge[data-status="killed"] {
+  background-color: var(--color-surface);
+  color: var(--color-text-muted);
+  text-decoration: line-through;
+}
+
+/* --- Category Tag --- */
+.category-tag {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* --- Buttons --- */
+.btn {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-medium);
+  border-radius: 0;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.btn-primary {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.btn-primary:hover {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+.btn-primary:focus-visible {
+  outline: 3px solid var(--color-text);
+  outline-offset: 2px;
+}
+
+.btn-secondary {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+.btn-secondary:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+/* --- Empty State --- */
+.empty-state {
+  text-align: center;
+  padding: var(--space-2xl);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  border: var(--border-medium);
+  border-style: dashed;
+}
+
+/* --- Footer --- */
+.site-footer {
+  border-top: var(--border-heavy);
+  padding: var(--space-md) var(--space-lg);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+/* ============================================================
+   Responsive Breakpoints
+   ============================================================ */
+
+/* 320px — small mobile */
+@media (max-width: 480px) {
+  .stats-bar {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .pipeline {
+    flex-direction: column;
+  }
+
+  .pipeline-stage {
+    border-right: none;
+    border-bottom: var(--border-medium);
+    min-width: auto;
+  }
+
+  .pipeline-stage:last-child {
+    border-bottom: none;
+  }
+
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .filters {
+    flex-direction: column;
+  }
+
+  .filter-group select {
+    min-width: auto;
+    width: 100%;
+  }
+}
+
+/* 768px — tablet */
+@media (min-width: 481px) and (max-width: 768px) {
+  .stats-bar {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .cards-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* 1024px — small desktop */
+@media (min-width: 769px) and (max-width: 1024px) {
+  .stats-bar {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .cards-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* 1440px — large desktop */
+@media (min-width: 1025px) {
+  .stats-bar {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .cards-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/examples/example-submission-1.md
+++ b/examples/example-submission-1.md
@@ -1,0 +1,93 @@
+# Prototype Submission
+
+> **Submission Title:** AI-Powered Inventory Alert System
+> **Submitter:** Alex Chen / @achen
+> **Date:** 2026-02-14
+> **Category:** ai-ml
+
+---
+
+## Problem Statement
+
+Our regional warehouse network (12 locations) relies on manual stock checks and static reorder thresholds to manage inventory across 8,400 SKUs. Warehouse coordinators spend 2-3 hours daily reviewing spreadsheets and ERP dashboards to identify items approaching stockout or accumulating excess. Despite this effort, we averaged 340 stockout events per quarter last year, each taking 3-5 days to resolve through emergency reorders at premium freight costs. On the other side, slow-moving overstock tied up an estimated $2.1M in dead inventory across all locations.
+
+The core issue is that static thresholds cannot account for seasonal demand shifts, promotional spikes, or regional variation. A coordinator in Portland sets the same reorder point year-round for sunscreen that a coordinator in Miami does, despite fundamentally different demand curves. By the time a human notices the pattern, the damage — lost sales or wasted capital — is already done.
+
+---
+
+## Dollar Value Framing
+
+- **Value type:** Cost saving
+- **Estimate:** $680,000/year
+  - Stockout reduction: 340 events/quarter x 60% reduction x $320 avg emergency freight premium = $261,120/year
+  - Overstock reduction: $2.1M dead inventory x 35% reduction x 18% annual carrying cost = $132,300/year
+  - Labor savings: 12 coordinators x 1.5 hrs/day saved x 250 working days x $48/hr avg = $216,000/year
+  - Waste reduction (perishables): ~$70,000/year based on current spoilage rates reduced by 40%
+- **Assumptions:**
+  - 60% stockout reduction is conservative; academic benchmarks for ML-based demand forecasting show 30-70% improvement over static methods
+  - Carrying cost of 18% is standard for warehoused goods (storage, insurance, depreciation, opportunity cost)
+  - Coordinators will reallocate saved time to exception handling and supplier negotiations, not be eliminated
+  - Model accuracy improves with 6+ months of feedback data
+- **Confidence level:** Medium
+
+---
+
+## Working Prototype
+
+- **Link:** [github.com/achen/inventory-alert](https://github.com/achen/inventory-alert)
+- **Tech stack:** Python 3.11, scikit-learn (Random Forest + Gradient Boosting), pandas, PostgreSQL, Slack SDK, Streamlit (dashboard), Docker
+- **How to run it:**
+  1. Clone the repo and run `docker compose up` to start PostgreSQL and the app
+  2. Load sample data: `python scripts/seed_data.py --source sample_data/`
+  3. Train model: `python train.py --lookback 90 --horizon 14`
+  4. Start alert service: `python alert_service.py` (sends to configured Slack channel)
+  5. View dashboard at `http://localhost:8501`
+
+---
+
+## Effort So Far
+
+- **Time invested:** ~60 hours over 5 weekends
+- **People involved:** Alex Chen (ML engineering), Dana Torres (warehouse ops, provided domain expertise and test data)
+- **Resources used:** Personal laptop, anonymized 18-month sales history export (approved by data team), free-tier Slack workspace for testing
+- **What was hardest:** Getting the demand signal right for promotional periods — the model initially treated promo spikes as anomalies rather than predictable patterns, which required adding a promotional calendar feature.
+
+---
+
+## What's Needed to Graduate
+
+- **Team size:** 2 engineers (1 ML, 1 backend) + 1 warehouse ops lead for 3 months, then 0.5 FTE ongoing maintenance
+- **Timeline:** 12-14 weeks to production pilot at 2 locations, 6 months for full rollout
+- **Budget:** ~$85,000 (engineering time: $60K, infrastructure: $15K/year for compute and monitoring, Slack Enterprise integration: $10K)
+- **Dependencies:**
+  - Read access to live ERP inventory and sales data (SAP RFC or API gateway)
+  - Slack Enterprise Grid approval for bot integration
+  - Warehouse ops team buy-in for a 4-week parallel-run validation period
+  - Data engineering team to set up a nightly ETL pipeline
+- **Key risks to graduation:**
+  - ERP API access may require a 6-8 week procurement and security review cycle
+  - Model retraining pipeline needs MLOps infrastructure we do not currently have
+  - If coordinators do not trust the alerts, adoption will stall regardless of accuracy
+
+---
+
+## Risk Assessment
+
+- **Data sensitivity:** Uses historical sales volumes and SKU metadata. No customer PII. Data was anonymized for prototyping; production would use internal data behind existing access controls.
+- **Security implications:** Slack bot requires write access to specific channels only. No external data egress. Model runs on internal infrastructure.
+- **Integration complexity:** Medium. Requires read-only connection to SAP and write access to Slack. No modifications to source systems. Dashboard is standalone.
+- **Compliance concerns:** None identified. No customer data, no regulated data categories. Standard internal tooling approval process applies.
+
+---
+
+## Demo
+
+- **Video walkthrough:** [drive.google.com/file/d/inventory-alert-demo](https://drive.google.com/file/d/inventory-alert-demo)
+- **Screenshots:** [github.com/achen/inventory-alert/docs/screenshots](https://github.com/achen/inventory-alert/tree/main/docs/screenshots)
+- **Live demo:** Available on request (requires VPN access to demo environment)
+
+---
+
+## Additional Context
+
+The prototype was tested against 18 months of historical data from 3 warehouse locations. Backtesting showed the model would have flagged 78% of actual stockout events with a 5-day lead time, compared to the current process which catches roughly 30% before they become critical. False positive rate was 12%, which is within the acceptable range for actionable alerts (coordinators indicated they would rather investigate a false alert than miss a real one). Dana Torres from warehouse ops has agreed to champion a pilot if this moves forward.

--- a/examples/example-submission-2.md
+++ b/examples/example-submission-2.md
@@ -1,0 +1,92 @@
+# Prototype Submission
+
+> **Submission Title:** Meeting Decision Recorder
+> **Submitter:** Priya Sharma / @psharma
+> **Date:** 2026-03-03
+> **Category:** automation
+
+---
+
+## Problem Statement
+
+In a 500-person organization running an average of 180 meetings per day, decisions and action items routinely disappear into the void. Meeting notes — when they exist — live in personal notebooks, scattered Google Docs, or Slack threads that no one revisits. A recurring pattern has emerged: teams spend 15-20 minutes in follow-up meetings re-establishing what was decided in the previous one because no one can locate the record. When disputes arise about what was agreed, there is no authoritative source.
+
+This is not a note-taking problem. People take notes. The problem is extraction and accountability: pulling structured decisions and action items (with owners and deadlines) out of unstructured conversation, and making them findable after the fact. Our Q4 internal survey showed that 67% of employees reported "unclear action items after meetings" as a top-3 productivity blocker. Engineering managers estimated they spend 3-4 hours per week chasing down whether decisions from prior meetings were actually executed.
+
+---
+
+## Dollar Value Framing
+
+- **Value type:** Cost saving
+- **Estimate:** $412,000/year
+  - Re-discussion time eliminated: 180 meetings/day x 22% with re-discussion x 15 min avg x 3.2 avg attendees x $62/hr avg loaded cost x 250 days = $246,000/year
+  - Manager follow-up time: 85 managers x 2 hrs/week saved x 48 working weeks x $78/hr avg loaded cost = $127,300/year
+  - Missed deadline reduction (downstream impact): estimated $38,700/year based on 23% reduction in slipped commitments at current rework cost rates
+- **Assumptions:**
+  - 22% re-discussion rate is from the Q4 survey (self-reported, likely conservative)
+  - Not all 180 daily meetings will use the tool immediately; estimate assumes 60% adoption within 6 months
+  - Dollar values use loaded cost (salary + benefits + overhead), not just salary
+  - Savings compound as the searchable decision archive grows over time
+- **Confidence level:** Medium
+
+---
+
+## Working Prototype
+
+- **Link:** [github.com/psharma/meeting-decision-recorder](https://github.com/psharma/meeting-decision-recorder)
+- **Tech stack:** Python 3.12, OpenAI Whisper (large-v3) for transcription, Claude API (Sonnet) for decision/action extraction, FastAPI, SQLite, Jinja2 templates for the web UI
+- **How to run it:**
+  1. Clone the repo and install dependencies: `pip install -r requirements.txt`
+  2. Set environment variables: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`
+  3. Start the server: `uvicorn app.main:app --reload`
+  4. Upload an audio file or paste a transcript at `http://localhost:8000`
+  5. View extracted decisions and action items in the web UI; search past meetings at `/search`
+
+---
+
+## Effort So Far
+
+- **Time invested:** ~45 hours over 3 weeks (evenings and one weekend sprint)
+- **People involved:** Priya Sharma (backend development), Tomoko Hayashi (tested with her team's actual meeting recordings, provided feedback on extraction accuracy)
+- **Resources used:** Personal API keys for Whisper and Claude (total API spend: ~$34), laptop with 16GB RAM for local Whisper inference testing, 22 meeting recordings donated by volunteers (with consent)
+- **What was hardest:** Distinguishing between actual decisions ("we will ship this by March 10") and hypothetical discussions ("we could potentially ship by March 10") — required careful prompt engineering and a two-pass extraction approach.
+
+---
+
+## What's Needed to Graduate
+
+- **Team size:** 1 backend engineer + 1 frontend engineer for 8 weeks, then 0.25 FTE maintenance
+- **Timeline:** 8 weeks to production MVP (calendar integration, SSO, persistent storage), 4 additional weeks for Google Meet/Zoom bot integration
+- **Budget:** ~$52,000 (engineering time: $38K, API costs at scale: $8K/year estimate based on 100 meetings/day x avg 30 min, infrastructure: $6K/year)
+- **Dependencies:**
+  - Google Workspace admin approval for Calendar API and Meet recording access
+  - SSO integration with corporate Okta instance
+  - Legal review of meeting recording consent requirements (varies by jurisdiction)
+  - Claude API enterprise agreement or upgrade from individual plan
+- **Key risks to graduation:**
+  - Recording consent is the biggest blocker — some jurisdictions require all-party consent, which changes the UX significantly
+  - Whisper transcription accuracy drops noticeably in meetings with heavy accents, cross-talk, or poor audio quality
+  - If the tool produces inaccurate decisions even 5% of the time, trust will erode quickly and people will stop using it
+
+---
+
+## Risk Assessment
+
+- **Data sensitivity:** High. Meeting audio and transcripts may contain sensitive business discussions, personnel matters, or strategic plans. Production system must enforce same access controls as the meeting itself (only attendees can view outputs).
+- **Security implications:** Audio files must be encrypted at rest and in transit. API calls to external services (Whisper, Claude) send meeting content to third-party servers — enterprise API agreements with data processing addendums are required. On-premises Whisper deployment is feasible and recommended.
+- **Integration complexity:** Medium-high. Calendar integration is straightforward, but meeting bot injection into Google Meet/Zoom requires platform-specific APIs and admin-level permissions. Real-time processing adds latency and reliability requirements.
+- **Compliance concerns:** GDPR and local privacy laws govern recording of conversations. Must implement: explicit recording consent mechanism, data retention policies (auto-delete after configurable period), right-to-deletion for individuals, and audit logging of who accessed what.
+
+---
+
+## Demo
+
+- **Video walkthrough:** [drive.google.com/file/d/meeting-recorder-demo](https://drive.google.com/file/d/meeting-recorder-demo)
+- **Screenshots:** [github.com/psharma/meeting-decision-recorder/docs/demo](https://github.com/psharma/meeting-decision-recorder/tree/main/docs/demo)
+- **Live demo:** [meeting-recorder-demo.internal.company.com](https://meeting-recorder-demo.internal.company.com) (internal network only, pre-loaded with sample data)
+
+---
+
+## Additional Context
+
+Tested with 22 real meeting recordings across 4 teams (engineering, product, operations, HR). Extraction accuracy benchmarked by having meeting participants verify outputs: 89% of actual decisions were captured, 94% of action items were captured with correct owners. The 11% missed decisions were predominantly implicit ones ("so we're not doing that then" — negation-based decisions where no explicit statement was made). The two-pass extraction approach (first pass: identify candidate decisions, second pass: validate and structure) reduced false positives from 31% to 7%. Tomoko's product team has been using it informally for 2 weeks and reported it "changed how they run meetings" — they now state decisions more explicitly because they know the tool is listening.

--- a/examples/example-submission-3.md
+++ b/examples/example-submission-3.md
@@ -1,0 +1,106 @@
+# Prototype Submission
+
+> **Submission Title:** Customer Feedback Classifier
+> **Submitter:** Marcus Johnson / @mjohnson
+> **Date:** 2026-01-27
+> **Category:** ai-ml
+
+---
+
+## Problem Statement
+
+Our customer support operation handles approximately 540 tickets per day across email, chat, and web forms. Every ticket enters a single general queue and is manually triaged by a 3-person routing team who read each one, assign a category, set a priority, and route it to the correct specialist group (billing, technical, product, shipping, account management). This manual triage process takes an average of 4.2 minutes per ticket and introduces a median 47-minute delay before a ticket reaches the right team.
+
+The cost is not just the routing team's time — it is what happens downstream. Urgent issues (service outages, security concerns, order cancellations within the refund window) sit in the general queue alongside password resets and feature requests. Last quarter, 23% of tickets were routed to the wrong team on the first attempt, requiring re-routing and adding an average of 2.3 hours to resolution time. Our CSAT scores for mis-routed tickets are 18 points lower than correctly routed ones. Customers do not care about our internal queue structure; they care that their urgent problem sat unread for an hour because it was categorized as "general inquiry."
+
+---
+
+## Dollar Value Framing
+
+- **Value type:** Cost saving
+- **Estimate:** $534,000/year
+  - Triage team labor: 3 FTEs x $58,000 avg salary x 1.35 benefits multiplier = $234,900/year (estimate 80% of this work automated, retaining 1 FTE for edge cases = $156,600 saved)
+  - Mis-routing rework: 540 tickets/day x 23% mis-routed x 2.3 hrs added resolution x $42/hr agent cost x 365 days = $1.15M, reduced by 70% = $189,800 saved (conservative; model accuracy exceeds human accuracy in testing)
+  - Faster urgent response: reducing median time-to-right-team from 47 min to ~3 min for critical tickets prevents estimated 8 escalations/month at $1,200 avg escalation cost + goodwill impact = $115,200/year
+  - CSAT improvement: not directly quantified but correlated with 12-15% reduction in churn for affected customer segment based on industry benchmarks
+  - Reduced agent context-switching from receiving wrongly-routed tickets: estimated $72,400/year
+- **Assumptions:**
+  - 540 tickets/day is a trailing 6-month average; volume has been growing ~8% quarterly
+  - 70% mis-routing reduction is based on prototype testing (model achieved 91% routing accuracy vs. human 77%)
+  - One triage FTE retained for escalations, ambiguous tickets, and model feedback
+  - Agent cost of $42/hr is loaded cost for L1/L2 support staff
+- **Confidence level:** High
+
+---
+
+## Working Prototype
+
+- **Link:** [github.com/mjohnson/feedback-classifier](https://github.com/mjohnson/feedback-classifier)
+- **Tech stack:** Python 3.11, Claude API (Haiku for classification, Sonnet for ambiguous cases), FastAPI, PostgreSQL, Redis (job queue), pandas for analytics, pytest
+- **How to run it:**
+  1. Clone the repo: `git clone https://github.com/mjohnson/feedback-classifier.git`
+  2. Copy `.env.example` to `.env` and set `ANTHROPIC_API_KEY` and `DATABASE_URL`
+  3. Start services: `docker compose up -d`
+  4. Seed with sample tickets: `python scripts/load_samples.py --count 500`
+  5. Run classifier: `python classify.py --mode batch` (or `--mode api` for real-time endpoint)
+  6. View results dashboard: `http://localhost:8000/dashboard`
+
+---
+
+## Effort So Far
+
+- **Time invested:** ~80 hours over 6 weeks
+- **People involved:** Marcus Johnson (development), Lisa Park (support ops manager, provided labeled training data and validated outputs), Raj Patel (infosec, reviewed data handling approach)
+- **Resources used:** Anthropic API (total spend: ~$47 during development and testing), anonymized export of 12,000 historical tickets with human-assigned categories (approved by support ops and legal), personal Docker environment
+- **What was hardest:** Building a reliable urgency detector — the difference between "my service is down" (critical) and "my service was down yesterday" (informational) requires genuine language understanding, not just keyword matching.
+
+---
+
+## What's Needed to Graduate
+
+- **Team size:** 2 engineers (1 backend, 1 integration) + 1 support ops liaison for 10 weeks, then 0.5 FTE ongoing
+- **Timeline:** 10 weeks to production pilot (shadow mode alongside human triage for 3 weeks, then gradual handoff), 16 weeks to full production
+- **Budget:** ~$94,000 (engineering time: $62K, API costs at production volume: $18K/year using Haiku for 95% of tickets with Sonnet escalation, infrastructure and monitoring: $14K/year)
+- **Dependencies:**
+  - API integration with Zendesk (our current ticketing system) for real-time ticket ingestion and routing
+  - Anthropic enterprise API agreement with data processing addendum
+  - Support ops team agreement on category taxonomy (current categories need cleanup; 4 of 18 categories overlap)
+  - 3-week shadow mode period where the model classifies but humans still route (for validation)
+- **Key risks to graduation:**
+  - Zendesk API rate limits may require a webhook-based architecture instead of polling, adding complexity
+  - Category taxonomy cleanup is a prerequisite that requires cross-team agreement (historically contentious)
+  - If the model misroutes an urgent ticket during pilot and a customer escalates, leadership may lose confidence regardless of overall accuracy improvement
+
+---
+
+## Risk Assessment
+
+- **Data sensitivity:** Moderate. Support tickets contain customer names, email addresses, and account identifiers. Some tickets include partial payment information (last 4 digits) or personal details shared in free-text descriptions. Production system must comply with existing customer data handling policies.
+- **Security implications:** Tickets are sent to Anthropic's API for classification. Enterprise API agreement required to ensure no data retention by the provider. Alternative: fine-tuned open-source model running on-premises (tested with Llama 3 — accuracy was 83% vs. 91% with Claude, but eliminates external data transmission).
+- **Integration complexity:** Medium. Zendesk has a mature API and webhook system. The classifier sits between ticket creation and queue assignment — it does not modify tickets, only adds metadata (category, priority, confidence score) and triggers routing rules. Rollback is straightforward: disable the webhook and revert to manual triage.
+- **Compliance concerns:** Customer data processing must align with existing privacy policy and data processing agreements. Tickets from EU customers fall under GDPR; the system must respect data residency requirements. Audit logging of all classification decisions is built into the prototype and required for production.
+
+---
+
+## Demo
+
+- **Video walkthrough:** [drive.google.com/file/d/feedback-classifier-demo](https://drive.google.com/file/d/feedback-classifier-demo)
+- **Screenshots:** [github.com/mjohnson/feedback-classifier/docs/screenshots](https://github.com/mjohnson/feedback-classifier/tree/main/docs/screenshots)
+- **Live demo:** [classifier-demo.internal.company.com](https://classifier-demo.internal.company.com) (internal network, pre-loaded with anonymized sample data)
+
+---
+
+## Additional Context
+
+The prototype was validated against 2,000 held-out tickets that were previously classified by the human triage team. Results:
+
+| Metric | Human Triage | Classifier |
+|--------|-------------|------------|
+| Category accuracy | 77% | 91% |
+| Priority accuracy | 71% | 88% |
+| Avg time to classify | 4.2 min | 1.8 sec |
+| Urgent ticket detection | 82% | 96% |
+
+The model uses a two-tier approach: Claude Haiku handles straightforward tickets (approximately 85% of volume) with high confidence. Tickets where Haiku's confidence falls below 0.85 are escalated to Claude Sonnet for deeper analysis. This keeps API costs manageable while maintaining accuracy on edge cases. The 9% of tickets where even Sonnet's confidence is below 0.80 are flagged for human review — these are genuinely ambiguous tickets that humans also struggle with.
+
+Lisa Park's support ops team has reviewed 500 of the model's classifications in detail and confirmed they would accept the routing decision in 93% of cases. The team has expressed strong interest in piloting this, as the triage role is widely regarded as the least desirable rotation in the support organization.


### PR DESCRIPTION
## Summary
- **Static dashboard** (index.html): pipeline visualization, stats bar, category breakdown, filterable submission cards, dark/light theme toggle
- **Neo-brutalist stylesheet** (styles.css): monochrome palette, heavy borders, CSS custom properties, responsive breakpoints, dark mode support
- **Sample data** (submissions.json): 10 submissions across different pipeline stages and categories for demo
- **3 example submissions**: AI Inventory Alert System ($680K/yr), Meeting Decision Recorder ($412K/yr), Customer Feedback Classifier ($534K/yr) — all following the submission template exactly

## Issues Closed
Closes #25, Closes #26, Closes #27, Closes #28, Closes #29, Closes #30

## Test plan
- [ ] Dashboard loads and renders from submissions.json
- [ ] Theme toggle switches between dark/light mode
- [ ] Filters work for status, category, and cycle
- [ ] Pipeline visualization shows correct counts per stage
- [ ] Responsive at 320px, 768px, 1024px, 1440px
- [ ] No rounded corners, no shadows, monochrome only
- [ ] Example submissions follow submission-template.md format exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)