### PR TITLE
fix: pre-release polish for public sharing

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -4,96 +4,106 @@
 
 # --- Status Labels ---
 
-- name: "status: submitted"
+- name: "submitted"
   color: "0E8A16"
   description: "Prototype has been submitted and is awaiting review"
 
-- name: "status: under-review"
+- name: "under-review"
   color: "FBCA04"
   description: "Prototype is being evaluated by the review panel"
 
-- name: "status: selected"
+- name: "selected"
   color: "1D76DB"
   description: "Prototype has been selected in the quarterly evaluation"
 
-- name: "status: invested"
+- name: "invested"
   color: "5319E7"
   description: "Prototype has been allocated dedicated time and resources"
 
-- name: "status: graduated"
+- name: "graduated"
   color: "0E8A16"
   description: "Prototype has graduated to production — funded, staffed, on the roadmap"
 
-- name: "status: iterated"
+- name: "iterated"
   color: "D93F0B"
   description: "Prototype needs refinement — queued for next cycle with feedback"
 
-- name: "status: shelved"
+- name: "shelved"
   color: "BFD4F2"
   description: "Prototype is valuable but not now — archived for future revisit"
 
-- name: "status: killed"
+- name: "killed"
   color: "B60205"
   description: "Prototype has been closed — learnings documented, loop closed"
 
 # --- Category Labels ---
 
-- name: "category: ai-ml"
+- name: "ai-ml"
   color: "C5DEF5"
   description: "AI, machine learning, NLP, or computer vision prototype"
 
-- name: "category: automation"
+- name: "automation"
   color: "C5DEF5"
   description: "Workflow automation, scripting, or process automation prototype"
 
-- name: "category: data"
+- name: "data"
   color: "C5DEF5"
   description: "Data pipeline, analytics, reporting, or data tooling prototype"
 
-- name: "category: ux"
+- name: "ux"
   color: "C5DEF5"
   description: "User experience, interface design, or accessibility prototype"
 
-- name: "category: infrastructure"
+- name: "infrastructure"
   color: "C5DEF5"
   description: "DevOps, platform, CI/CD, or infrastructure tooling prototype"
 
-- name: "category: process"
+- name: "process"
   color: "C5DEF5"
   description: "Business process improvement or operational efficiency prototype"
 
-- name: "category: other"
+- name: "other"
   color: "C5DEF5"
   description: "Prototype that does not fit existing categories"
 
 # --- Priority Labels ---
 
-- name: "priority: top-5"
+- name: "top-5"
   color: "0E8A16"
   description: "Top 5 — rewarded with recognition and fast-tracked to graduation review"
 
-- name: "priority: top-15"
+- name: "top-15"
   color: "FBCA04"
   description: "Top 15 — invested with 2-3 months of dedicated engineering time"
 
-- name: "priority: not-selected"
+- name: "not-selected"
   color: "E4E669"
   description: "Not selected this cycle — feedback provided for resubmission"
 
 # --- Cycle Labels ---
 
-- name: "cycle: Q1-2026"
+- name: "Q1-2026"
   color: "D4C5F9"
   description: "Submitted or evaluated in Q1 2026 cycle"
 
-- name: "cycle: Q2-2026"
+- name: "Q2-2026"
   color: "D4C5F9"
   description: "Submitted or evaluated in Q2 2026 cycle"
 
-- name: "cycle: Q3-2026"
+- name: "Q3-2026"
   color: "D4C5F9"
   description: "Submitted or evaluated in Q3 2026 cycle"
 
-- name: "cycle: Q4-2026"
+- name: "Q4-2026"
   color: "D4C5F9"
   description: "Submitted or evaluated in Q4 2026 cycle"
+
+# --- Workflow Labels ---
+
+- name: "quarterly-report"
+  color: "BFDADC"
+  description: "Auto-generated quarterly report issue"
+
+- name: "needs-revision"
+  color: "E99695"
+  description: "Submission is missing required fields — needs revision"

--- a/.github/workflows/quarterly-report.yml
+++ b/.github/workflows/quarterly-report.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      contents: read
 
     steps:
       - name: Generate quarterly report

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Internal notes — not part of the template
+RAW-THINKING.md
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Node modules (if using npx serve locally)
+node_modules/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Update the following for your organization:
 - Apply the labels from `.github/labels.yml`
 - Create a GitHub Project board with columns: Submitted, Under Review, Selected, Invested, Graduated, Shelved, Killed
 
+### Step 3b: Preview the dashboard
+The dashboard is a static site that needs an HTTP server (it fetches JSON via `fetch()`). To preview locally:
+```bash
+npx serve dashboard/
+```
+Then open the URL shown in your terminal.
+
 ### Step 4: Announce it
 Send the repo link to your engineering org. Point them to `docs/team-manifest/submitters-guide.md` and the example submissions in `examples/`. The lower the friction, the more submissions you get.
 
@@ -116,6 +123,13 @@ Hackathons create artificial urgency and exclude people who cannot dedicate a we
 
 **Why quarterly evaluation?**
 Frequent enough to maintain momentum. Infrequent enough to accumulate a meaningful pool of submissions. Aligned with how most organizations already plan and budget.
+
+---
+
+## Notes for Maintainers
+
+- **Claude Code permissions**: `.claude/settings.json` ships with broad permissions for development convenience. Review and tighten before giving write access to contributors.
+- **Dashboard serving**: The dashboard uses `fetch()` so it needs an HTTP server. Use `npx serve dashboard/` locally.
 
 ---
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -116,6 +116,7 @@
         'selected',
         'invested',
         'graduated',
+        'iterated',
         'shelved',
         'killed'
       ];


### PR DESCRIPTION
## Summary
- Add `.gitignore` to exclude RAW-THINKING.md (internal notes) and OS files
- Fix label names in `labels.yml` — remove namespace prefixes (`status: submitted` -> `submitted`) to match issue templates, workflows, and dashboard
- Add missing `iterated` stage to dashboard pipeline visualization
- Add `submissions/` directory with `.gitkeep` for actual prototype submissions
- Add `contents: read` permission to quarterly-report workflow
- Document HTTP server requirement (`npx serve dashboard/`) and settings.json permissiveness in README

## Test plan
- [ ] RAW-THINKING.md excluded from git tracking
- [ ] Label names in labels.yml match issue template auto-labels and workflow queries
- [ ] Dashboard pipeline shows all 8 stages including "iterated"
- [ ] submissions/ directory exists in repo
- [ ] Quarterly report workflow has sufficient permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)