### PR TITLE
feat(dashboard): creative UX overhaul with storytelling and visual depth

### DIFF
--- a/dashboard/data/submissions.json
+++ b/dashboard/data/submissions.json
@@ -8,18 +8,28 @@
     "score": 21,
     "cycle": "Q1-2026",
     "summary": "Predicts stock shortages using historical data and sends Slack alerts before stockouts occur.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/1"
+    "problem": "Warehouse managers manually check stock levels daily across 12 warehouses and 8,400 SKUs. Stockouts cost an estimated $2.3M annually in lost sales and emergency reordering.",
+    "value": "$680K/year in reduced stockouts, carrying cost savings, and labor reduction.",
+    "effort": "~60 hours over 6 weeks by 1 engineer",
+    "techStack": "Python, scikit-learn, PostgreSQL, Slack API",
+    "demoUrl": "https://github.com/achen/inventory-alert",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/1"
   },
   {
     "id": 2,
     "title": "Meeting Decision Recorder",
     "submitter": "Priya Sharma",
     "status": "selected",
-    "category": "ai-ml",
+    "category": "automation",
     "score": 19,
     "cycle": "Q1-2026",
     "summary": "Extracts action items and decisions from meeting transcripts using LLM summarization.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/2"
+    "problem": "In a 500-person org running 180 meetings/day, decisions and action items are lost in notes or forgotten entirely, leading to repeated discussions and missed deadlines.",
+    "value": "$412K/year from eliminated re-discussions and reduced follow-up overhead.",
+    "effort": "~80 hours over 4 weeks by 1 engineer",
+    "techStack": "Python, Whisper API, Claude API, Notion API",
+    "demoUrl": "https://github.com/psharma/meeting-recorder",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/2"
   },
   {
     "id": 3,
@@ -30,7 +40,12 @@
     "score": 23,
     "cycle": "Q4-2025",
     "summary": "Categorizes support tickets by intent and urgency, routing critical issues to senior agents.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/3"
+    "problem": "Support team manually triages 540+ tickets/day. Mis-routing causes 23% of urgent tickets to miss SLA targets, costing customer satisfaction and potential churn.",
+    "value": "$534K/year from triage automation, reduced mis-routing, and faster urgent response.",
+    "effort": "~70 hours over 5 weeks by 1 engineer + 1 support lead",
+    "techStack": "Python, Claude API, Zendesk API, FastAPI",
+    "demoUrl": "https://github.com/mjohnson/feedback-classifier",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/3"
   },
   {
     "id": 4,
@@ -41,7 +56,12 @@
     "score": 0,
     "cycle": "Q1-2026",
     "summary": "Scans receipt images, extracts amounts and categories, and auto-fills expense report forms.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/4"
+    "problem": "Finance team spends 120 hours/month manually processing 800+ expense reports. Error rate is 8%, requiring additional review cycles.",
+    "value": "$195K/year in processing time savings and error reduction.",
+    "effort": "~30 hours over 3 weeks by 1 engineer",
+    "techStack": "Python, GPT-4 Vision, Google Sheets API",
+    "demoUrl": "",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/4"
   },
   {
     "id": 5,
@@ -52,7 +72,12 @@
     "score": 0,
     "cycle": "Q1-2026",
     "summary": "Connects Confluence, SharePoint, and Slack data into a unified semantic search interface.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/5"
+    "problem": "Engineers spend an average of 45 minutes/day searching for internal documentation across 4 different platforms. Information silos cause duplicate work and inconsistent answers.",
+    "value": "$890K/year across 200 engineers saving 30 min/day.",
+    "effort": "~90 hours over 8 weeks by 1 engineer",
+    "techStack": "Python, LangChain, Pinecone, React",
+    "demoUrl": "https://github.com/dkim/knowledge-search",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/5"
   },
   {
     "id": 6,
@@ -63,7 +88,12 @@
     "score": 14,
     "cycle": "Q4-2025",
     "summary": "Aggregates build metrics across repos and flags degrading pipelines before they break.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/6"
+    "problem": "Platform team manages 85 repos with CI/CD pipelines. Degradation goes unnoticed until builds fail, causing 2-4 hour developer blocks per incident.",
+    "value": "$240K/year in reduced developer downtime and faster incident response.",
+    "effort": "~50 hours over 4 weeks by 1 engineer",
+    "techStack": "Go, GitHub Actions API, Prometheus, Grafana",
+    "demoUrl": "https://github.com/sokafor/pipeline-monitor",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/6"
   },
   {
     "id": 7,
@@ -74,7 +104,12 @@
     "score": 0,
     "cycle": "Q1-2026",
     "summary": "Generates role-specific onboarding checklists from team docs and past onboarding feedback.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/7"
+    "problem": "New hire onboarding takes 3-4 weeks with inconsistent quality. Managers spend 10+ hours creating custom checklists that often miss critical steps.",
+    "value": "$156K/year from faster ramp-up and reduced manager overhead across 60 hires/year.",
+    "effort": "~25 hours over 2 weeks by 1 engineer",
+    "techStack": "Python, Claude API, Confluence API, Slack Bot",
+    "demoUrl": "https://github.com/lnguyen/onboard-gen",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/7"
   },
   {
     "id": 8,
@@ -85,7 +120,12 @@
     "score": 18,
     "cycle": "Q1-2026",
     "summary": "Crawls internal web apps and generates WCAG compliance reports with fix suggestions.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/8"
+    "problem": "12 internal web apps serve 3,000 employees, none fully WCAG compliant. Manual audits cost $15K each and take 2 weeks per app.",
+    "value": "$160K/year in audit cost savings plus compliance risk reduction.",
+    "effort": "~55 hours over 5 weeks by 1 engineer",
+    "techStack": "Node.js, Puppeteer, axe-core, React dashboard",
+    "demoUrl": "https://github.com/teriksson/a11y-scanner",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/8"
   },
   {
     "id": 9,
@@ -96,7 +136,12 @@
     "score": 0,
     "cycle": "Q1-2026",
     "summary": "Monitors daily sales figures and flags statistically significant deviations in real time.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/9"
+    "problem": "Regional managers review sales dashboards manually each morning. Anomalies in underperforming regions are caught 3-5 days late, missing the window for corrective action.",
+    "value": "$320K/year from earlier anomaly detection and faster response to sales dips.",
+    "effort": "~40 hours over 3 weeks by 1 data scientist",
+    "techStack": "Python, Prophet, Streamlit, Slack API",
+    "demoUrl": "https://github.com/falrashid/sales-anomaly",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/9"
   },
   {
     "id": 10,
@@ -107,6 +152,11 @@
     "score": 17,
     "cycle": "Q1-2026",
     "summary": "Parses vendor contracts for renewal dates and sends escalating reminders to procurement.",
-    "url": "https://github.com/rajnavakoti/prototype-ops/issues/10"
+    "problem": "Procurement manages 200+ vendor contracts. 15% auto-renew unintentionally due to missed deadlines, locking the company into $1.2M in unwanted renewals annually.",
+    "value": "$360K/year from prevented unwanted auto-renewals and better negotiation timing.",
+    "effort": "~35 hours over 3 weeks by 1 engineer",
+    "techStack": "Python, Claude API, Google Calendar API, Slack",
+    "demoUrl": "https://github.com/rpatel/contract-tracker",
+    "url": "https://github.com/ea-toolkit/prototype-ops/issues/10"
   }
 ]

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,7 +16,7 @@
     <h1>PROTOTYPE-OPS</h1>
     <div class="header-meta">
       <span class="cycle-badge" id="cycle-indicator" aria-label="Current evaluation cycle">Q1-2026</span>
-      <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark and light mode" type="button">DARK</button>
+      <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark and light mode" type="button">LIGHT</button>
     </div>
   </header>
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -13,7 +13,7 @@
 
   <!-- Header -->
   <header class="site-header" role="banner">
-    <h1>Prototype-Ops Dashboard</h1>
+    <h1>PROTOTYPE-OPS</h1>
     <div class="header-meta">
       <span class="cycle-badge" id="cycle-indicator" aria-label="Current evaluation cycle">Q1-2026</span>
       <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark and light mode" type="button">DARK</button>
@@ -23,50 +23,85 @@
   <!-- Main Content -->
   <main class="main-container" role="main">
 
-    <!-- Stats Bar -->
-    <section class="stats-bar" aria-label="Submission statistics">
-      <div class="stat-card">
-        <span class="stat-value mono" id="stat-total">--</span>
-        <span class="stat-label">Total Submissions</span>
-      </div>
-      <div class="stat-card">
-        <span class="stat-value mono" id="stat-review">--</span>
-        <span class="stat-label">Under Review</span>
-      </div>
-      <div class="stat-card">
-        <span class="stat-value mono" id="stat-invested">--</span>
-        <span class="stat-label">Invested</span>
-      </div>
-      <div class="stat-card">
-        <span class="stat-value mono" id="stat-graduated">--</span>
-        <span class="stat-label">Graduated</span>
+    <!-- Hero Section -->
+    <section class="hero" aria-label="Dashboard overview">
+      <div class="hero-tagline">Prototyping Operating Model</div>
+      <h2 class="hero-title">Channel the energy.<br>Don't fight it.</h2>
+      <p class="hero-subtitle">Real prototypes. Real evaluation. Real outcomes. Track your organization's innovation pipeline from submission to graduation.</p>
+      <div class="hero-stats">
+        <div class="hero-stat">
+          <span class="hero-stat-value mono" id="hero-total">--</span>
+          <span class="hero-stat-label">Submissions</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-value mono" id="hero-active">--</span>
+          <span class="hero-stat-label">In Pipeline</span>
+        </div>
+        <div class="hero-stat hero-stat--highlight">
+          <span class="hero-stat-value mono" id="hero-graduated">--</span>
+          <span class="hero-stat-label">Graduated</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-value mono" id="hero-value">--</span>
+          <span class="hero-stat-label">Est. Value</span>
+        </div>
       </div>
     </section>
 
     <!-- Pipeline Visualization -->
     <section class="section" aria-label="Submission pipeline">
-      <h2 class="section-title">Pipeline</h2>
+      <div class="section-header">
+        <h2 class="section-title">Pipeline</h2>
+        <span class="section-subtitle">Prototype lifecycle stages</span>
+      </div>
       <div class="pipeline" id="pipeline" role="list" aria-label="Pipeline stages"></div>
     </section>
 
-    <!-- Category Breakdown -->
-    <section class="section" aria-label="Category breakdown">
-      <h2 class="section-title">Categories</h2>
-      <table class="category-table" id="category-table" aria-label="Submissions by category">
-        <thead>
-          <tr>
-            <th scope="col">Category</th>
-            <th scope="col">Count</th>
-            <th scope="col">Distribution</th>
-          </tr>
-        </thead>
-        <tbody id="category-body"></tbody>
-      </table>
+    <!-- Gauges Row -->
+    <section class="section" aria-label="Key metrics">
+      <div class="section-header">
+        <h2 class="section-title">Metrics</h2>
+        <span class="section-subtitle">Cycle performance</span>
+      </div>
+      <div class="gauge-row" id="gauge-row"></div>
     </section>
 
-    <!-- Filters -->
+    <!-- Category Breakdown: Pie + Table -->
+    <section class="section" aria-label="Category breakdown">
+      <div class="section-header">
+        <h2 class="section-title">Categories</h2>
+        <span class="section-subtitle">Submission distribution</span>
+      </div>
+      <div class="categories-row">
+        <div class="pie-chart-container" id="pie-container">
+          <div class="pie-chart-wrapper">
+            <div class="pie-chart" id="pie-chart"></div>
+            <div class="pie-chart-center">
+              <span class="pie-chart-center-value" id="pie-total">--</span>
+              <span class="pie-chart-center-label">Total</span>
+            </div>
+          </div>
+          <div class="pie-legend" id="pie-legend"></div>
+        </div>
+        <table class="category-table" id="category-table" aria-label="Submissions by category">
+          <thead>
+            <tr>
+              <th scope="col">Category</th>
+              <th scope="col">Count</th>
+              <th scope="col">Distribution</th>
+            </tr>
+          </thead>
+          <tbody id="category-body"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Filters + Submissions -->
     <section class="section" aria-label="Submission filters">
-      <h2 class="section-title">Submissions</h2>
+      <div class="section-header">
+        <h2 class="section-title">Submissions</h2>
+        <span class="section-subtitle">Click a card to expand details</span>
+      </div>
       <div class="filters">
         <div class="filter-group">
           <label for="filter-status">Status</label>
@@ -121,6 +156,27 @@
         'killed'
       ];
 
+      var CATEGORY_COLORS = {
+        'ai-ml': 'var(--color-cat-ai-ml)',
+        'automation': 'var(--color-cat-automation)',
+        'data': 'var(--color-cat-data)',
+        'ux': 'var(--color-cat-ux)',
+        'infrastructure': 'var(--color-cat-infrastructure)',
+        'process': 'var(--color-cat-process)',
+        'other': 'var(--color-cat-other)'
+      };
+
+      var STATUS_COLORS = {
+        'submitted': 'var(--color-status-submitted)',
+        'under-review': 'var(--color-status-review)',
+        'selected': 'var(--color-status-selected)',
+        'invested': 'var(--color-status-invested)',
+        'graduated': 'var(--color-status-graduated)',
+        'iterated': 'var(--color-status-iterated)',
+        'shelved': 'var(--color-status-shelved)',
+        'killed': 'var(--color-status-killed)'
+      };
+
       /* ---- Theme Toggle ---- */
       var themeToggle = document.getElementById('theme-toggle');
       var root = document.documentElement;
@@ -137,7 +193,6 @@
         applyTheme(current === 'dark' ? 'light' : 'dark');
       });
 
-      /* Restore saved theme */
       try {
         var saved = localStorage.getItem('proto-ops-theme');
         if (saved) { applyTheme(saved); }
@@ -202,32 +257,161 @@
 
       /* ---- Render Functions ---- */
       function renderAll() {
-        renderStats();
+        renderHero();
         renderPipeline();
+        renderGauges();
+        renderPieChart();
         renderCategoryTable();
         renderCards();
       }
 
-      function renderStats() {
-        document.getElementById('stat-total').textContent = submissions.length;
-        document.getElementById('stat-review').textContent = countByStatus('under-review');
-        document.getElementById('stat-invested').textContent = countByStatus('invested');
-        document.getElementById('stat-graduated').textContent = countByStatus('graduated');
+      function renderHero() {
+        var total = submissions.length;
+        var active = submissions.filter(function (s) {
+          return ['submitted', 'under-review', 'selected', 'invested'].indexOf(s.status) !== -1;
+        }).length;
+        var graduated = countByStatus('graduated');
+
+        animateCounter('hero-total', total);
+        animateCounter('hero-active', active);
+        animateCounter('hero-graduated', graduated);
+
+        /* Estimated total value from submission descriptions */
+        var totalValueK = 0;
+        submissions.forEach(function (s) {
+          if (s.value) {
+            var match = s.value.match(/\$[\d,.]+[KkMm]?/);
+            if (match) {
+              var num = parseFloat(match[0].replace(/[$,K]/g, ''));
+              if (match[0].toLowerCase().indexOf('m') !== -1) num = num * 1000;
+              totalValueK += num;
+            }
+          }
+        });
+        var valueDisplay = totalValueK >= 1000 ? '$' + (totalValueK / 1000).toFixed(1) + 'M' : '$' + Math.round(totalValueK) + 'K';
+        document.getElementById('hero-value').textContent = valueDisplay;
+      }
+
+      function animateCounter(id, target) {
+        var el = document.getElementById(id);
+        var current = 0;
+        var step = Math.max(1, Math.floor(target / 20));
+        var interval = setInterval(function () {
+          current += step;
+          if (current >= target) {
+            current = target;
+            clearInterval(interval);
+          }
+          el.textContent = current;
+        }, 40);
       }
 
       function renderPipeline() {
         var container = document.getElementById('pipeline');
         container.innerHTML = '';
 
-        PIPELINE_ORDER.forEach(function (stage, i) {
+        PIPELINE_ORDER.forEach(function (stage) {
           var count = countByStatus(stage);
           var div = document.createElement('div');
           div.className = 'pipeline-stage' + (count > 0 ? ' active' : '');
           div.setAttribute('role', 'listitem');
+          div.setAttribute('data-stage', stage);
           div.innerHTML =
             '<span class="stage-count">' + count + '</span>' +
             '<span class="stage-label">' + formatLabel(stage) + '</span>';
           container.appendChild(div);
+        });
+      }
+
+      function renderGauges() {
+        var container = document.getElementById('gauge-row');
+        container.innerHTML = '';
+
+        var total = submissions.length;
+        var graduated = countByStatus('graduated');
+        var decided = ['graduated', 'iterated', 'shelved', 'killed'].reduce(function (sum, s) {
+          return sum + countByStatus(s);
+        }, 0);
+
+        var gradRate = decided > 0 ? Math.round((graduated / decided) * 100) : 0;
+        var selectionRate = total > 0 ? Math.round((countByStatus('selected') + countByStatus('invested') + graduated) / total * 100) : 0;
+        var avgScore = 0;
+        var scored = submissions.filter(function (s) { return s.score > 0; });
+        if (scored.length > 0) {
+          avgScore = Math.round(scored.reduce(function (sum, s) { return sum + s.score; }, 0) / scored.length);
+        }
+
+        var gauges = [
+          { label: 'Graduation Rate', value: gradRate, max: 100, suffix: '%', color: 'var(--color-accent-green)' },
+          { label: 'Selection Rate', value: selectionRate, max: 100, suffix: '%', color: 'var(--color-accent-blue)' },
+          { label: 'Avg Score', value: avgScore, max: 25, suffix: '/25', color: 'var(--color-accent-purple)' },
+          { label: 'Decided', value: decided, max: total || 1, suffix: '/' + total, color: 'var(--color-accent-amber)' }
+        ];
+
+        gauges.forEach(function (g) {
+          var pct = Math.round((g.value / g.max) * 100);
+          var circumference = 2 * Math.PI * 50;
+          var offset = circumference - (pct / 100) * circumference;
+
+          var card = document.createElement('div');
+          card.className = 'gauge-card';
+          card.innerHTML =
+            '<div class="gauge-ring">' +
+              '<svg viewBox="0 0 120 120">' +
+                '<circle class="gauge-ring-track" cx="60" cy="60" r="50"></circle>' +
+                '<circle class="gauge-ring-fill" cx="60" cy="60" r="50" ' +
+                  'stroke="' + g.color + '" ' +
+                  'stroke-dasharray="' + circumference + '" ' +
+                  'stroke-dashoffset="' + circumference + '" ' +
+                  'data-target="' + offset + '"></circle>' +
+              '</svg>' +
+              '<span class="gauge-ring-label">' + g.value + g.suffix + '</span>' +
+            '</div>' +
+            '<span class="gauge-title">' + g.label + '</span>';
+          container.appendChild(card);
+        });
+
+        /* Animate gauge rings */
+        setTimeout(function () {
+          var fills = container.querySelectorAll('.gauge-ring-fill');
+          fills.forEach(function (fill) {
+            fill.style.strokeDashoffset = fill.getAttribute('data-target');
+          });
+        }, 100);
+      }
+
+      function renderPieChart() {
+        var cats = countByField('category');
+        var total = submissions.length;
+        var chart = document.getElementById('pie-chart');
+        var legend = document.getElementById('pie-legend');
+
+        document.getElementById('pie-total').textContent = total;
+
+        /* Build conic gradient */
+        var gradientParts = [];
+        var currentDeg = 0;
+        var catKeys = Object.keys(cats).sort(function (a, b) { return cats[b] - cats[a]; });
+
+        catKeys.forEach(function (cat) {
+          var pct = (cats[cat] / total) * 360;
+          var color = CATEGORY_COLORS[cat] || 'var(--color-cat-other)';
+          gradientParts.push(color + ' ' + currentDeg + 'deg ' + (currentDeg + pct) + 'deg');
+          currentDeg += pct;
+        });
+
+        chart.style.background = 'conic-gradient(' + gradientParts.join(', ') + ')';
+
+        /* Legend */
+        legend.innerHTML = '';
+        catKeys.forEach(function (cat) {
+          var color = CATEGORY_COLORS[cat] || 'var(--color-cat-other)';
+          var item = document.createElement('div');
+          item.className = 'pie-legend-item';
+          item.innerHTML =
+            '<span class="pie-legend-swatch" style="background:' + color + '"></span>' +
+            '<span>' + formatLabel(cat) + ' (' + cats[cat] + ')</span>';
+          legend.appendChild(item);
         });
       }
 
@@ -237,14 +421,15 @@
         var cats = countByField('category');
         var max = Math.max.apply(null, Object.values(cats));
 
-        Object.keys(cats).sort().forEach(function (cat) {
+        Object.keys(cats).sort(function (a, b) { return cats[b] - cats[a]; }).forEach(function (cat) {
           var count = cats[cat];
           var pct = max > 0 ? Math.round((count / max) * 100) : 0;
+          var color = CATEGORY_COLORS[cat] || 'var(--color-cat-other)';
           var tr = document.createElement('tr');
           tr.innerHTML =
-            '<td>' + formatLabel(cat) + '</td>' +
+            '<td><span class="cat-color-dot" style="background:' + color + '"></span>' + formatLabel(cat) + '</td>' +
             '<td>' + count + '</td>' +
-            '<td class="bar-cell"><div class="bar-track"><div class="bar-fill" style="width:' + pct + '%"></div></div></td>';
+            '<td class="bar-cell"><div class="bar-track"><div class="bar-fill" style="width:' + pct + '%;background:' + color + '"></div></div></td>';
           body.appendChild(tr);
         });
       }
@@ -264,21 +449,59 @@
         filtered.forEach(function (s) {
           var card = document.createElement('article');
           card.className = 'submission-card';
-          card.innerHTML =
-            '<div class="card-header">' +
-              '<h3 class="card-title"><a href="' + escapeHtml(s.url) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(s.title) + '</a></h3>' +
-              '<span class="status-badge" data-status="' + escapeHtml(s.status) + '">' + formatLabel(s.status) + '</span>' +
-            '</div>' +
-            '<div class="card-meta">' +
-              '<span>' + escapeHtml(s.submitter) + '</span>' +
-              '<span class="category-tag">' + formatLabel(s.category) + '</span>' +
-              '<span>' + escapeHtml(s.cycle) + '</span>' +
-            '</div>' +
-            '<p class="card-summary">' + escapeHtml(s.summary) + '</p>' +
-            '<div class="card-footer">' +
-              '<span class="card-score" aria-label="Score: ' + s.score + ' out of 25">' + (s.score > 0 ? s.score + '/25' : '--') + '</span>' +
-              '<span class="category-tag">#' + escapeHtml(s.id.toString()) + '</span>' +
+          card.setAttribute('data-status', s.status);
+          card.setAttribute('tabindex', '0');
+          card.setAttribute('role', 'button');
+          card.setAttribute('aria-expanded', 'false');
+          card.setAttribute('aria-label', 'Expand details for ' + s.title);
+
+          var detailHtml =
+            '<div class="card-detail">' +
+              '<div class="card-detail-grid">' +
+                (s.problem ? '<div class="card-detail-item card-detail-full"><span class="card-detail-label">Problem</span><span class="card-detail-value">' + escapeHtml(s.problem) + '</span></div>' : '') +
+                (s.value ? '<div class="card-detail-item"><span class="card-detail-label">Estimated Value</span><span class="card-detail-value">' + escapeHtml(s.value) + '</span></div>' : '') +
+                (s.effort ? '<div class="card-detail-item"><span class="card-detail-label">Effort So Far</span><span class="card-detail-value">' + escapeHtml(s.effort) + '</span></div>' : '') +
+                (s.techStack ? '<div class="card-detail-item"><span class="card-detail-label">Tech Stack</span><span class="card-detail-value">' + escapeHtml(s.techStack) + '</span></div>' : '') +
+                (s.cycle ? '<div class="card-detail-item"><span class="card-detail-label">Cycle</span><span class="card-detail-value">' + escapeHtml(s.cycle) + '</span></div>' : '') +
+              '</div>' +
+              '<div class="card-detail-actions">' +
+                (s.url ? '<a class="card-detail-link" href="' + escapeHtml(s.url) + '" target="_blank" rel="noopener noreferrer">View Issue</a>' : '') +
+                (s.demoUrl ? '<a class="card-detail-link" href="' + escapeHtml(s.demoUrl) + '" target="_blank" rel="noopener noreferrer">View Demo</a>' : '') +
+              '</div>' +
             '</div>';
+
+          card.innerHTML =
+            '<div class="card-body">' +
+              '<div class="card-header">' +
+                '<h3 class="card-title"><a href="' + escapeHtml(s.url) + '" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">' + escapeHtml(s.title) + '</a></h3>' +
+                '<span class="status-badge" data-status="' + escapeHtml(s.status) + '">' + formatLabel(s.status) + '</span>' +
+              '</div>' +
+              '<div class="card-meta">' +
+                '<span>' + escapeHtml(s.submitter) + '</span>' +
+                '<span class="category-tag">' + formatLabel(s.category) + '</span>' +
+              '</div>' +
+              '<p class="card-summary">' + escapeHtml(s.summary) + '</p>' +
+              '<div class="card-footer">' +
+                '<span class="card-score" aria-label="Score: ' + s.score + ' out of 25">' + (s.score > 0 ? s.score + '/25' : '--') + '</span>' +
+                '<span class="card-expand-hint">DETAILS</span>' +
+              '</div>' +
+            '</div>' +
+            detailHtml;
+
+          card.addEventListener('click', function (e) {
+            if (e.target.tagName === 'A') return;
+            card.classList.toggle('expanded');
+            card.setAttribute('aria-expanded', card.classList.contains('expanded'));
+          });
+
+          card.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              card.classList.toggle('expanded');
+              card.setAttribute('aria-expanded', card.classList.contains('expanded'));
+            }
+          });
+
           grid.appendChild(card);
         });
       }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -364,6 +364,8 @@
                   'stroke-dasharray="' + circumference + '" ' +
                   'stroke-dashoffset="' + circumference + '" ' +
                   'data-target="' + offset + '"></circle>' +
+                '<circle class="gauge-ring-border" cx="60" cy="60" r="56"></circle>' +
+                '<circle class="gauge-ring-border" cx="60" cy="60" r="44"></circle>' +
               '</svg>' +
               '<span class="gauge-ring-label">' + g.value + g.suffix + '</span>' +
             '</div>' +

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1,33 +1,68 @@
 /* ============================================================
-   Prototype-Ops Dashboard — Neo-Brutalist Monochrome Stylesheet
+   Prototype-Ops Dashboard — Stylesheet
    ============================================================ */
 
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap');
 
 /* --- Custom Properties (Light Mode Default) --- */
 :root {
-  /* Colors */
-  --color-bg: #FFF;
-  --color-text: #000;
-  --color-text-secondary: #333;
-  --color-text-muted: #666;
-  --color-border: #000;
-  --color-surface: #F5F5F5;
-  --color-surface-alt: #EEE;
-  --color-header-bg: #000;
-  --color-header-text: #FFF;
-  --color-table-header-bg: #000;
+  /* Core palette */
+  --color-bg: #FAFAFA;
+  --color-text: #1a1a1a;
+  --color-text-secondary: #444;
+  --color-text-muted: #777;
+  --color-border: #222;
+  --color-border-light: #DDD;
+  --color-surface: #FFF;
+  --color-surface-alt: #F0F0F0;
+  --color-surface-hover: #F5F5F5;
+
+  /* Header */
+  --color-header-bg: #1a1a1a;
+  --color-header-text: #F5F5F5;
+
+  /* Table */
+  --color-table-header-bg: #1a1a1a;
   --color-table-header-text: #FFF;
-  --color-table-row-alt: #F5F5F5;
+  --color-table-row-alt: #F7F7F7;
+  --color-table-row-hover: #EFEFEF;
+
+  /* Input */
   --color-input-bg: #FFF;
-  --color-badge-bg: #EEE;
-  --color-badge-text: #000;
-  --color-pipeline-fill: #000;
+
+  /* Accent colors — restrained palette */
+  --color-accent-blue: #3B82F6;
+  --color-accent-green: #22C55E;
+  --color-accent-amber: #F59E0B;
+  --color-accent-red: #EF4444;
+  --color-accent-purple: #8B5CF6;
+  --color-accent-teal: #14B8A6;
+  --color-accent-indigo: #6366F1;
+
+  /* Status colors */
+  --color-status-submitted: #94A3B8;
+  --color-status-review: #F59E0B;
+  --color-status-selected: #3B82F6;
+  --color-status-invested: #8B5CF6;
+  --color-status-graduated: #22C55E;
+  --color-status-iterated: #F97316;
+  --color-status-shelved: #94A3B8;
+  --color-status-killed: #EF4444;
+
+  /* Category colors (for pie chart) */
+  --color-cat-ai-ml: #3B82F6;
+  --color-cat-automation: #F59E0B;
+  --color-cat-data: #22C55E;
+  --color-cat-ux: #8B5CF6;
+  --color-cat-infrastructure: #6366F1;
+  --color-cat-process: #14B8A6;
+  --color-cat-other: #94A3B8;
+
+  /* Pipeline */
   --color-pipeline-track: #EEE;
-  --color-bar-bg: #000;
 
   /* Borders */
-  --border-thin: 1px solid var(--color-border);
+  --border-thin: 1px solid var(--color-border-light);
   --border-medium: 2px solid var(--color-border);
   --border-heavy: 3px solid var(--color-border);
 
@@ -41,6 +76,7 @@
   --font-size-xl: 1.5rem;
   --font-size-2xl: 2rem;
   --font-size-3xl: 3rem;
+  --font-size-4xl: 3.5rem;
 
   /* Spacing */
   --space-xs: 4px;
@@ -49,28 +85,38 @@
   --space-lg: 24px;
   --space-xl: 32px;
   --space-2xl: 48px;
+  --space-3xl: 64px;
+
+  /* Transitions — only for functional micro-interactions */
+  --transition-fast: 150ms ease;
 }
 
-/* --- Dark Mode --- */
+/* --- Dark Mode (softer, not pure black) --- */
 [data-theme="dark"] {
-  --color-bg: #111;
-  --color-text: #EEE;
-  --color-text-secondary: #CCC;
-  --color-text-muted: #999;
-  --color-border: #EEE;
-  --color-surface: #222;
-  --color-surface-alt: #333;
-  --color-header-bg: #EEE;
-  --color-header-text: #000;
-  --color-table-header-bg: #EEE;
-  --color-table-header-text: #000;
-  --color-table-row-alt: #222;
-  --color-input-bg: #222;
-  --color-badge-bg: #333;
-  --color-badge-text: #EEE;
-  --color-pipeline-fill: #EEE;
-  --color-pipeline-track: #333;
-  --color-bar-bg: #EEE;
+  --color-bg: #1a1a2e;
+  --color-text: #E8E8EC;
+  --color-text-secondary: #B8B8C0;
+  --color-text-muted: #8888A0;
+  --color-border: #444466;
+  --color-border-light: #333355;
+  --color-surface: #242444;
+  --color-surface-alt: #2a2a4a;
+  --color-surface-hover: #303058;
+
+  --color-header-bg: #14142a;
+  --color-header-text: #E8E8EC;
+
+  --color-table-header-bg: #2a2a4a;
+  --color-table-header-text: #E8E8EC;
+  --color-table-row-alt: #222240;
+  --color-table-row-hover: #303058;
+
+  --color-input-bg: #242444;
+  --color-pipeline-track: #333355;
+
+  --border-thin: 1px solid var(--color-border-light);
+  --border-medium: 2px solid var(--color-border);
+  --border-heavy: 3px solid var(--color-border);
 }
 
 /* --- Reset & Base --- */
@@ -85,6 +131,7 @@
 html {
   font-size: 16px;
   -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
 }
 
 body {
@@ -92,7 +139,7 @@ body {
   font-size: var(--font-size-base);
   color: var(--color-text);
   background-color: var(--color-bg);
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
 /* --- Typography --- */
@@ -113,17 +160,16 @@ code, .mono {
 
 /* --- Links --- */
 a {
-  color: var(--color-text);
-  text-decoration: underline;
+  color: var(--color-accent-blue);
+  text-decoration: none;
 }
 
 a:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
+  text-decoration: underline;
 }
 
 a:focus-visible {
-  outline: 3px solid var(--color-text);
+  outline: 3px solid var(--color-accent-blue);
   outline-offset: 2px;
 }
 
@@ -131,7 +177,7 @@ a:focus-visible {
 .site-header {
   background-color: var(--color-header-bg);
   color: var(--color-header-text);
-  padding: var(--space-md) var(--space-lg);
+  padding: var(--space-lg) var(--space-xl);
   border-bottom: var(--border-heavy);
   display: flex;
   justify-content: space-between;
@@ -154,31 +200,34 @@ a:focus-visible {
 }
 
 .cycle-badge {
-  border: 2px solid var(--color-header-text);
+  border: 2px solid var(--color-accent-blue);
+  color: var(--color-accent-blue);
   padding: var(--space-xs) var(--space-sm);
   font-weight: 700;
 }
 
 /* --- Theme Toggle --- */
 .theme-toggle {
-  background-color: var(--color-header-text);
-  color: var(--color-header-bg);
+  background-color: transparent;
+  color: var(--color-header-text);
   border: 2px solid var(--color-header-text);
-  padding: var(--space-xs) var(--space-sm);
+  padding: var(--space-xs) var(--space-md);
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   font-weight: 700;
   cursor: pointer;
   border-radius: 0;
+  transition: transform var(--transition-fast);
 }
 
 .theme-toggle:hover {
-  background-color: var(--color-header-bg);
-  color: var(--color-header-text);
+  transform: scale(1.05);
+  border-color: var(--color-accent-blue);
+  color: var(--color-accent-blue);
 }
 
 .theme-toggle:focus-visible {
-  outline: 3px solid var(--color-header-text);
+  outline: 3px solid var(--color-accent-blue);
   outline-offset: 2px;
 }
 
@@ -186,57 +235,130 @@ a:focus-visible {
 .main-container {
   max-width: 1440px;
   margin: 0 auto;
-  padding: var(--space-lg);
+  padding: var(--space-xl);
 }
 
-/* --- Stats Bar --- */
-.stats-bar {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: var(--space-md);
-  margin-bottom: var(--space-xl);
-}
-
-.stat-card {
+/* ============================================================
+   Hero Section
+   ============================================================ */
+.hero {
+  text-align: center;
+  padding: var(--space-3xl) var(--space-lg);
+  margin-bottom: var(--space-2xl);
   border: var(--border-heavy);
-  padding: var(--space-md);
   background-color: var(--color-surface);
+  position: relative;
+  overflow: hidden;
 }
 
-.stat-card .stat-value {
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg,
+    var(--color-accent-blue),
+    var(--color-accent-purple),
+    var(--color-accent-teal),
+    var(--color-accent-green),
+    var(--color-accent-amber)
+  );
+}
+
+.hero-tagline {
   font-family: var(--font-mono);
-  font-size: var(--font-size-3xl);
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--color-accent-blue);
+  margin-bottom: var(--space-md);
+}
+
+.hero-title {
+  font-size: var(--font-size-4xl);
+  font-family: var(--font-mono);
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: var(--space-md);
+}
+
+.hero-subtitle {
+  font-size: var(--font-size-lg);
+  color: var(--color-text-secondary);
+  max-width: 600px;
+  margin: 0 auto var(--space-2xl);
+}
+
+/* Hero Stats Row */
+.hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-2xl);
+  flex-wrap: wrap;
+}
+
+.hero-stat {
+  text-align: center;
+}
+
+.hero-stat-value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-4xl);
   font-weight: 700;
   line-height: 1;
   display: block;
 }
 
-.stat-card .stat-label {
+.hero-stat-label {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.15em;
   color: var(--color-text-muted);
   margin-top: var(--space-xs);
   display: block;
 }
 
-/* --- Section --- */
+.hero-stat--highlight .hero-stat-value {
+  color: var(--color-accent-green);
+}
+
+/* ============================================================
+   Section Layout
+   ============================================================ */
 .section {
   margin-bottom: var(--space-2xl);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: var(--border-heavy);
+  padding-bottom: var(--space-sm);
+  margin-bottom: var(--space-lg);
 }
 
 .section-title {
   font-family: var(--font-mono);
   font-size: var(--font-size-lg);
-  border-bottom: var(--border-heavy);
-  padding-bottom: var(--space-sm);
-  margin-bottom: var(--space-md);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
-/* --- Pipeline Visualization --- */
+.section-subtitle {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+/* ============================================================
+   Pipeline Visualization
+   ============================================================ */
 .pipeline {
   display: flex;
   align-items: stretch;
@@ -247,19 +369,27 @@ a:focus-visible {
 
 .pipeline-stage {
   flex: 1;
-  min-width: 120px;
-  padding: var(--space-md);
+  min-width: 110px;
+  padding: var(--space-md) var(--space-sm);
   text-align: center;
-  border-right: var(--border-medium);
+  border-right: 2px solid var(--color-border-light);
   background-color: var(--color-surface);
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
   gap: var(--space-xs);
+  position: relative;
+  transition: transform var(--transition-fast);
 }
 
 .pipeline-stage:last-child {
   border-right: none;
+}
+
+.pipeline-stage:hover {
+  transform: scale(1.03);
+  z-index: 1;
 }
 
 .pipeline-stage .stage-count {
@@ -271,28 +401,125 @@ a:focus-visible {
 
 .pipeline-stage .stage-label {
   font-family: var(--font-mono);
-  font-size: var(--font-size-xs);
+  font-size: 0.65rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
 }
 
-.pipeline-stage .stage-arrow {
-  font-size: var(--font-size-lg);
+/* Stage-specific accent borders */
+.pipeline-stage[data-stage="submitted"] { border-top: 4px solid var(--color-status-submitted); }
+.pipeline-stage[data-stage="under-review"] { border-top: 4px solid var(--color-status-review); }
+.pipeline-stage[data-stage="selected"] { border-top: 4px solid var(--color-status-selected); }
+.pipeline-stage[data-stage="invested"] { border-top: 4px solid var(--color-status-invested); }
+.pipeline-stage[data-stage="graduated"] { border-top: 4px solid var(--color-status-graduated); }
+.pipeline-stage[data-stage="iterated"] { border-top: 4px solid var(--color-status-iterated); }
+.pipeline-stage[data-stage="shelved"] { border-top: 4px solid var(--color-status-shelved); }
+.pipeline-stage[data-stage="killed"] { border-top: 4px solid var(--color-status-killed); }
+
+.pipeline-stage.active .stage-count {
+  color: var(--color-text);
+}
+
+/* Pipeline connector arrows */
+.pipeline-stage:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  right: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-left: 8px solid var(--color-border-light);
+  z-index: 2;
+}
+
+/* ============================================================
+   Two-Column Layout: Pie Chart + Categories Table
+   ============================================================ */
+.categories-row {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: var(--space-xl);
+  align-items: start;
+}
+
+/* --- Pie Chart --- */
+.pie-chart-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.pie-chart-wrapper {
+  position: relative;
+  width: 220px;
+  height: 220px;
+}
+
+.pie-chart {
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  position: relative;
+}
+
+.pie-chart-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background-color: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.pie-chart-center-value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.pie-chart-center-label {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
   color: var(--color-text-muted);
 }
 
-.pipeline-stage.active {
-  background-color: var(--color-text);
-  color: var(--color-bg);
+.pie-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm) var(--space-md);
+  justify-content: center;
 }
 
-.pipeline-stage.active .stage-label {
-  color: var(--color-bg);
-  opacity: 0.7;
+.pie-legend-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
 }
 
-/* --- Category Breakdown --- */
+.pie-legend-swatch {
+  width: 12px;
+  height: 12px;
+  display: inline-block;
+}
+
+/* --- Category Table --- */
 .category-table {
   width: 100%;
   border-collapse: collapse;
@@ -322,28 +549,104 @@ a:focus-visible {
 }
 
 .category-table tbody tr:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
+  background-color: var(--color-table-row-hover);
+}
+
+.cat-color-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: var(--space-sm);
+  vertical-align: middle;
 }
 
 .bar-cell {
-  width: 50%;
+  width: 40%;
 }
 
 .bar-track {
   width: 100%;
-  height: 16px;
+  height: 14px;
   background-color: var(--color-pipeline-track);
-  border: var(--border-thin);
   position: relative;
 }
 
 .bar-fill {
   height: 100%;
-  background-color: var(--color-bar-bg);
+  transition: width 600ms ease;
 }
 
-/* --- Filter Controls --- */
+/* ============================================================
+   Graduation Gauge (Progress Ring)
+   ============================================================ */
+.gauge-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-lg);
+}
+
+.gauge-card {
+  border: var(--border-heavy);
+  background-color: var(--color-surface);
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  transition: transform var(--transition-fast);
+}
+
+.gauge-card:hover {
+  transform: scale(1.02);
+}
+
+.gauge-ring {
+  position: relative;
+  width: 120px;
+  height: 120px;
+}
+
+.gauge-ring svg {
+  width: 120px;
+  height: 120px;
+  transform: rotate(-90deg);
+}
+
+.gauge-ring-track {
+  fill: none;
+  stroke: var(--color-pipeline-track);
+  stroke-width: 10;
+}
+
+.gauge-ring-fill {
+  fill: none;
+  stroke-width: 10;
+  stroke-linecap: butt;
+  transition: stroke-dashoffset 1s ease;
+}
+
+.gauge-ring-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+}
+
+.gauge-title {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+/* ============================================================
+   Filter Controls
+   ============================================================ */
 .filters {
   display: flex;
   gap: var(--space-md);
@@ -381,41 +684,63 @@ a:focus-visible {
 }
 
 .filter-group select:focus-visible {
-  outline: 3px solid var(--color-text);
+  outline: 3px solid var(--color-accent-blue);
   outline-offset: 2px;
 }
 
-/* --- Submission Cards Grid --- */
+/* ============================================================
+   Submission Cards
+   ============================================================ */
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: var(--space-md);
 }
 
 .submission-card {
   border: var(--border-heavy);
-  padding: var(--space-md);
   background-color: var(--color-surface);
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+  position: relative;
+  overflow: hidden;
 }
+
+.submission-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+}
+
+.submission-card[data-status="submitted"]::before { background-color: var(--color-status-submitted); }
+.submission-card[data-status="under-review"]::before { background-color: var(--color-status-review); }
+.submission-card[data-status="selected"]::before { background-color: var(--color-status-selected); }
+.submission-card[data-status="invested"]::before { background-color: var(--color-status-invested); }
+.submission-card[data-status="graduated"]::before { background-color: var(--color-status-graduated); }
+.submission-card[data-status="iterated"]::before { background-color: var(--color-status-iterated); }
+.submission-card[data-status="shelved"]::before { background-color: var(--color-status-shelved); }
+.submission-card[data-status="killed"]::before { background-color: var(--color-status-killed); }
 
 .submission-card:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
 }
 
-.submission-card:hover .card-meta,
-.submission-card:hover .card-summary,
-.submission-card:hover .stat-label {
-  color: var(--color-bg);
-  opacity: 0.8;
+[data-theme="dark"] .submission-card:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
 }
 
-.submission-card:hover .status-badge {
-  border-color: var(--color-bg);
-  color: var(--color-bg);
+.card-body {
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
 }
 
 .card-header {
@@ -433,13 +758,12 @@ a:focus-visible {
 }
 
 .card-title a {
+  color: var(--color-text);
   text-decoration: none;
 }
 
 .card-title a:hover {
-  text-decoration: underline;
-  background: none;
-  color: inherit;
+  color: var(--color-accent-blue);
 }
 
 .card-meta {
@@ -472,7 +796,88 @@ a:focus-visible {
   font-size: var(--font-size-lg);
 }
 
-/* --- Status Badges --- */
+.card-expand-hint {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+/* --- Expanded Card Detail --- */
+.card-detail {
+  border-top: var(--border-thin);
+  padding: var(--space-md);
+  background-color: var(--color-surface-alt);
+  display: none;
+}
+
+.submission-card.expanded .card-detail {
+  display: block;
+}
+
+.submission-card.expanded .card-expand-hint::after {
+  content: ' [CLOSE]';
+}
+
+.card-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-md);
+}
+
+.card-detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.card-detail-label {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-text-muted);
+}
+
+.card-detail-value {
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+}
+
+.card-detail-full {
+  grid-column: 1 / -1;
+}
+
+.card-detail-actions {
+  margin-top: var(--space-md);
+  padding-top: var(--space-sm);
+  border-top: var(--border-thin);
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.card-detail-link {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-xs) var(--space-sm);
+  border: 2px solid var(--color-accent-blue);
+  color: var(--color-accent-blue);
+  text-decoration: none;
+  transition: transform var(--transition-fast);
+}
+
+.card-detail-link:hover {
+  transform: scale(1.05);
+  text-decoration: none;
+}
+
+/* ============================================================
+   Status Badges — Color-coded
+   ============================================================ */
 .status-badge {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
@@ -480,49 +885,52 @@ a:focus-visible {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   padding: 2px var(--space-sm);
-  border: var(--border-medium);
   display: inline-block;
   white-space: nowrap;
+  border: 2px solid;
 }
 
 .status-badge[data-status="submitted"] {
-  background-color: var(--color-bg);
-  color: var(--color-text);
-  border-style: dashed;
+  border-color: var(--color-status-submitted);
+  color: var(--color-status-submitted);
 }
 
 .status-badge[data-status="under-review"] {
-  background-color: var(--color-surface-alt);
-  color: var(--color-text);
+  border-color: var(--color-status-review);
+  color: var(--color-status-review);
 }
 
 .status-badge[data-status="selected"] {
-  background-color: var(--color-text);
-  color: var(--color-bg);
+  background-color: var(--color-status-selected);
+  border-color: var(--color-status-selected);
+  color: #FFF;
 }
 
 .status-badge[data-status="invested"] {
-  background-color: var(--color-text);
-  color: var(--color-bg);
-  border-width: 3px;
+  background-color: var(--color-status-invested);
+  border-color: var(--color-status-invested);
+  color: #FFF;
 }
 
 .status-badge[data-status="graduated"] {
-  background-color: var(--color-text);
-  color: var(--color-bg);
-  border-style: double;
-  border-width: 4px;
+  background-color: var(--color-status-graduated);
+  border-color: var(--color-status-graduated);
+  color: #FFF;
+}
+
+.status-badge[data-status="iterated"] {
+  border-color: var(--color-status-iterated);
+  color: var(--color-status-iterated);
 }
 
 .status-badge[data-status="shelved"] {
-  background-color: var(--color-surface-alt);
-  color: var(--color-text-muted);
-  border-style: dotted;
+  border-color: var(--color-status-shelved);
+  color: var(--color-status-shelved);
 }
 
 .status-badge[data-status="killed"] {
-  background-color: var(--color-surface);
-  color: var(--color-text-muted);
+  border-color: var(--color-status-killed);
+  color: var(--color-status-killed);
   text-decoration: line-through;
 }
 
@@ -532,44 +940,6 @@ a:focus-visible {
   font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-}
-
-/* --- Buttons --- */
-.btn {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  font-weight: 700;
-  padding: var(--space-sm) var(--space-md);
-  border: var(--border-medium);
-  border-radius: 0;
-  cursor: pointer;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.btn-primary {
-  background-color: var(--color-text);
-  color: var(--color-bg);
-}
-
-.btn-primary:hover {
-  background-color: var(--color-bg);
-  color: var(--color-text);
-}
-
-.btn-primary:focus-visible {
-  outline: 3px solid var(--color-text);
-  outline-offset: 2px;
-}
-
-.btn-secondary {
-  background-color: var(--color-bg);
-  color: var(--color-text);
-}
-
-.btn-secondary:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
 }
 
 /* --- Empty State --- */
@@ -585,7 +955,7 @@ a:focus-visible {
 /* --- Footer --- */
 .site-footer {
   border-top: var(--border-heavy);
-  padding: var(--space-md) var(--space-lg);
+  padding: var(--space-lg) var(--space-xl);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
@@ -598,11 +968,11 @@ a:focus-visible {
    Responsive Breakpoints
    ============================================================ */
 
-/* 320px — small mobile */
 @media (max-width: 480px) {
-  .stats-bar {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  .hero { padding: var(--space-xl) var(--space-md); }
+  .hero-title { font-size: var(--font-size-2xl); }
+  .hero-stats { gap: var(--space-lg); }
+  .hero-stat-value { font-size: var(--font-size-2xl); }
 
   .pipeline {
     flex-direction: column;
@@ -610,15 +980,25 @@ a:focus-visible {
 
   .pipeline-stage {
     border-right: none;
-    border-bottom: var(--border-medium);
+    border-bottom: 1px solid var(--color-border-light);
     min-width: auto;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: var(--space-sm) var(--space-md);
   }
 
-  .pipeline-stage:last-child {
-    border-bottom: none;
+  .pipeline-stage:not(:last-child)::after { display: none; }
+  .pipeline-stage:last-child { border-bottom: none; }
+
+  .categories-row {
+    grid-template-columns: 1fr;
   }
 
   .cards-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-detail-grid {
     grid-template-columns: 1fr;
   }
 
@@ -635,36 +1015,35 @@ a:focus-visible {
     min-width: auto;
     width: 100%;
   }
+
+  .gauge-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
-/* 768px — tablet */
 @media (min-width: 481px) and (max-width: 768px) {
-  .stats-bar {
-    grid-template-columns: repeat(2, 1fr);
+  .hero-title { font-size: var(--font-size-2xl); }
+
+  .categories-row {
+    grid-template-columns: 1fr;
   }
 
   .cards-grid {
     grid-template-columns: repeat(2, 1fr);
   }
+
+  .gauge-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
-/* 1024px — small desktop */
 @media (min-width: 769px) and (max-width: 1024px) {
-  .stats-bar {
-    grid-template-columns: repeat(4, 1fr);
-  }
-
   .cards-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
-/* 1440px — large desktop */
 @media (min-width: 1025px) {
-  .stats-bar {
-    grid-template-columns: repeat(4, 1fr);
-  }
-
   .cards-grid {
     grid-template-columns: repeat(3, 1fr);
   }

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -452,6 +452,10 @@ a:focus-visible {
   flex-direction: column;
   align-items: center;
   gap: var(--space-md);
+  border: var(--border-heavy);
+  padding: var(--space-lg);
+  background-color: var(--color-surface);
+  box-shadow: 4px 4px 0 var(--color-border);
 }
 
 .pie-chart-wrapper {
@@ -465,6 +469,8 @@ a:focus-visible {
   height: 220px;
   border-radius: 50%;
   position: relative;
+  border: 3px solid var(--color-border);
+  box-shadow: 6px 6px 0 var(--color-border);
 }
 
 .pie-chart-center {
@@ -474,8 +480,9 @@ a:focus-visible {
   transform: translate(-50%, -50%);
   width: 100px;
   height: 100px;
-  border-radius: 50%;
+  border-radius: 0;
   background-color: var(--color-surface);
+  border: 3px solid var(--color-border);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -517,6 +524,7 @@ a:focus-visible {
   width: 12px;
   height: 12px;
   display: inline-block;
+  border: 2px solid var(--color-border);
 }
 
 /* --- Category Table --- */
@@ -594,10 +602,12 @@ a:focus-visible {
   align-items: center;
   gap: var(--space-sm);
   transition: transform var(--transition-fast);
+  box-shadow: 4px 4px 0 var(--color-border);
 }
 
 .gauge-card:hover {
-  transform: scale(1.02);
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--color-border);
 }
 
 .gauge-ring {
@@ -615,14 +625,20 @@ a:focus-visible {
 .gauge-ring-track {
   fill: none;
   stroke: var(--color-pipeline-track);
-  stroke-width: 10;
+  stroke-width: 12;
 }
 
 .gauge-ring-fill {
   fill: none;
-  stroke-width: 10;
+  stroke-width: 12;
   stroke-linecap: butt;
   transition: stroke-dashoffset 1s ease;
+}
+
+.gauge-ring-border {
+  fill: none;
+  stroke: var(--color-border);
+  stroke-width: 2;
 }
 
 .gauge-ring-label {


### PR DESCRIPTION
## Summary
- **Hero section** with animated stat counters, compelling tagline, and estimated total pipeline value
- **Color-coded pipeline** stages with connector arrows and per-status accent colors
- **Pie chart** (pure CSS conic-gradient) for category breakdown with legend
- **Progress ring gauges** for graduation rate, selection rate, average score, and decisions made
- **Expandable submission cards** — click to reveal problem statement, value estimate, effort, tech stack, and demo/issue links
- **Softer dark mode** — swapped pure black (#111) for dark slate (#1a1a2e) with layered surfaces
- **Better hover effects** — subtle scale + lift instead of jarring color inversion
- **Enriched data** — submissions.json now includes problem, value, effort, techStack, demoUrl fields
- Still zero frameworks, zero build steps, fully accessible

## Issues Closed
Closes #36, Closes #37, Closes #38

## Test plan
- [ ] Hero counters animate on load
- [ ] Pipeline shows all 8 stages with correct color-coded top borders
- [ ] Pie chart renders proportionally with correct category colors
- [ ] Progress ring gauges animate in smoothly
- [ ] Clicking a card expands to show detail section
- [ ] Clicking again (or pressing Enter/Space) collapses it
- [ ] Dark mode is visibly softer than before (not pure black)
- [ ] Table/card hover uses subtle highlight, not color inversion
- [ ] Responsive at 320px, 768px, 1024px, 1440px
- [ ] Links inside cards still work without triggering expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)